### PR TITLE
Digest API v1.5 foundation

### DIFF
--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -12,6 +12,7 @@ The live flag definitions are:
 - `enable_audit_logging`: default `true`; controls whether moderation actions should be recorded for audit visibility
 - `enable_per_message_unread`: default `false`; gates the Phase 4 rollout from thread-level unread semantics to per-message unread semantics
 - `enable_inbox_digest`: default `false`; gates the Phase 4 digest endpoint and hook scaffolding rollout
+- `enable_inbox_digest_v1_5`: default `false`; temporary gate for Digest API v1.5 rollout behavior
 
 Rollout note for `enable_per_message_unread`:
 
@@ -30,6 +31,13 @@ Rollout note for `enable_inbox_digest`:
 - Enable in internal environments first, then ramp gradually.
 - Use digest payloads as additive support for unread workflows, not as a replacement for existing inbox contracts during rollout.
 - Confirm digest ordering and total-unread semantics match inbox contract expectations before broad rollout.
+
+Rollout note for `enable_inbox_digest_v1_5`:
+
+- Treat this as a temporary rollout flag for 1.7 only.
+- Enable first in internal/canary environments, then ramp gradually after digest correctness metrics remain stable.
+- Keep the public digest response contract backward-compatible while this flag is enabled.
+- Remove this flag and related branching before the 1.7 release cut; final Digest API v1 behavior should be enabled by default.
 
 ## Phase 3 Rollout Gates
 

--- a/scripts/setup-appwrite.ts
+++ b/scripts/setup-appwrite.ts
@@ -921,6 +921,11 @@ async function setupFeatureFlags() {
         enabled: false,
         key: "enable_inbox_digest",
     });
+    await ensureFeatureFlagDocument({
+        description: "Enable inbox digest v1.5 staged rollout behavior",
+        enabled: false,
+        key: "enable_inbox_digest_v1_5",
+    });
 }
 
 async function ensureFeatureFlagDocument(params: {

--- a/src/__tests__/api-routes/inbox-digest-route.test.ts
+++ b/src/__tests__/api-routes/inbox-digest-route.test.ts
@@ -22,6 +22,7 @@ vi.mock("@/lib/inbox", () => ({
 vi.mock("@/lib/feature-flags", () => ({
     FEATURE_FLAGS: {
         ENABLE_INBOX_DIGEST: "enable_inbox_digest",
+        ENABLE_INBOX_DIGEST_V1_5: "enable_inbox_digest_v1_5",
     },
     getFeatureFlag: mockGetFeatureFlag,
 }));
@@ -46,7 +47,7 @@ describe("inbox digest route", () => {
 
     it("returns 404 when digest flag is disabled", async () => {
         mockSession.mockResolvedValue({ $id: "user-1" });
-        mockGetFeatureFlag.mockResolvedValue(false);
+        mockGetFeatureFlag.mockResolvedValueOnce(false);
 
         const response = await GET(
             new NextRequest("http://localhost/api/inbox/digest"),
@@ -56,6 +57,33 @@ describe("inbox digest route", () => {
         expect(response.status).toBe(404);
         expect(data.error).toContain("not enabled");
         expect(mockListInboxDigest).not.toHaveBeenCalled();
+    });
+
+    it("passes digest v1.5 mode when enabled", async () => {
+        mockSession.mockResolvedValue({ $id: "user-1" });
+        mockGetFeatureFlag
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce(true);
+        mockListInboxDigest.mockResolvedValue({
+            contractVersion: "thread_v1",
+            contextId: undefined,
+            contextKind: undefined,
+            items: [],
+            totalUnreadCount: 0,
+        });
+
+        const response = await GET(
+            new NextRequest("http://localhost/api/inbox/digest"),
+        );
+
+        expect(response.status).toBe(200);
+        expect(mockListInboxDigest).toHaveBeenCalledWith({
+            contextId: undefined,
+            contextKind: undefined,
+            limit: 50,
+            useDigestV15: true,
+            userId: "user-1",
+        });
     });
 
     it("rejects invalid limit", async () => {
@@ -135,6 +163,7 @@ describe("inbox digest route", () => {
             contextId: "conversation-1",
             contextKind: "conversation",
             limit: 25,
+            useDigestV15: true,
             userId: "user-1",
         });
         expect(data.totalUnreadCount).toBe(2);

--- a/src/__tests__/feature-flags.test.ts
+++ b/src/__tests__/feature-flags.test.ts
@@ -26,6 +26,12 @@ describe("Feature Flags", () => {
             );
         });
 
+        it("should have ENABLE_INBOX_DIGEST_V1_5 flag with correct key", () => {
+            expect(FEATURE_FLAGS.ENABLE_INBOX_DIGEST_V1_5).toBe(
+                "enable_inbox_digest_v1_5",
+            );
+        });
+
         it("should have all required feature flags defined", () => {
             // Ensure the FEATURE_FLAGS object has the expected structure
             expect(FEATURE_FLAGS).toBeDefined();
@@ -35,6 +41,9 @@ describe("Feature Flags", () => {
                 "string",
             );
             expect(typeof FEATURE_FLAGS.ENABLE_INBOX_DIGEST).toBe("string");
+            expect(typeof FEATURE_FLAGS.ENABLE_INBOX_DIGEST_V1_5).toBe(
+                "string",
+            );
         });
     });
 

--- a/src/__tests__/inbox.test.ts
+++ b/src/__tests__/inbox.test.ts
@@ -424,4 +424,70 @@ describe("inbox", () => {
         expect(digest.totalUnreadCount).toBe(2);
         expect(digest.contractVersion).toBe("thread_v1");
     });
+
+    it("keeps v1.5 digest mode backward-compatible during rollout", async () => {
+        mockListDocuments.mockImplementation(
+            async (_databaseId, collectionId) => {
+                if (collectionId === "inbox-items-collection") {
+                    return {
+                        documents: [
+                            {
+                                $id: "mention-a",
+                                userId: "user-1",
+                                kind: "mention",
+                                contextKind: "conversation",
+                                contextId: "conversation-1",
+                                messageId: "message-a",
+                                latestActivityAt: "2026-03-11T11:00:00.000Z",
+                                previewText: "older",
+                                authorUserId: "user-2",
+                            },
+                            {
+                                $id: "mention-b",
+                                userId: "user-1",
+                                kind: "mention",
+                                contextKind: "conversation",
+                                contextId: "conversation-1",
+                                messageId: "message-b",
+                                latestActivityAt: "2026-03-11T12:00:00.000Z",
+                                previewText: "newer",
+                                authorUserId: "user-3",
+                            },
+                        ],
+                    };
+                }
+
+                if (collectionId === "profiles-collection") {
+                    return {
+                        documents: [
+                            {
+                                userId: "user-2",
+                                displayName: "Alice",
+                            },
+                            {
+                                userId: "user-3",
+                                displayName: "Bob",
+                            },
+                        ],
+                    };
+                }
+
+                return { documents: [] };
+            },
+        );
+        mockGetNotificationSettings.mockResolvedValue(null);
+
+        const digest = await listInboxDigest({
+            contextId: "conversation-1",
+            contextKind: "conversation",
+            limit: 1,
+            useDigestV15: true,
+            userId: "user-1",
+        });
+
+        expect(digest.contractVersion).toBe("thread_v1");
+        expect(digest.totalUnreadCount).toBe(2);
+        expect(digest.items).toHaveLength(1);
+        expect(digest.items[0]?.id).toBe("mention-b");
+    });
 });

--- a/src/app/api/inbox/digest/route.ts
+++ b/src/app/api/inbox/digest/route.ts
@@ -54,6 +54,10 @@ export async function GET(request: NextRequest) {
         );
     }
 
+    const digestV15Enabled = await getFeatureFlag(
+        FEATURE_FLAGS.ENABLE_INBOX_DIGEST_V1_5,
+    ).catch(() => false);
+
     const { searchParams } = new URL(request.url);
     const limit = parseLimit(searchParams.get("limit"));
     if (!limit) {
@@ -90,6 +94,7 @@ export async function GET(request: NextRequest) {
             contextId,
             contextKind,
             limit,
+            useDigestV15: digestV15Enabled,
             userId: session.$id,
         });
 

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -10,6 +10,7 @@ export const FEATURE_FLAGS = {
     ENABLE_AUDIT_LOGGING: "enable_audit_logging",
     ENABLE_PER_MESSAGE_UNREAD: "enable_per_message_unread",
     ENABLE_INBOX_DIGEST: "enable_inbox_digest",
+    ENABLE_INBOX_DIGEST_V1_5: "enable_inbox_digest_v1_5",
 } as const;
 
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS];
@@ -20,6 +21,7 @@ const DEFAULT_FLAGS: Record<FeatureFlagKey, boolean> = {
     [FEATURE_FLAGS.ENABLE_AUDIT_LOGGING]: true,
     [FEATURE_FLAGS.ENABLE_PER_MESSAGE_UNREAD]: false,
     [FEATURE_FLAGS.ENABLE_INBOX_DIGEST]: false,
+    [FEATURE_FLAGS.ENABLE_INBOX_DIGEST_V1_5]: false,
 };
 
 // Cache for feature flags to reduce database calls
@@ -165,6 +167,7 @@ export async function setFeatureFlag(
  * - enable_audit_logging: Enable audit logging for moderation actions.
  * - enable_per_message_unread: Enable per-message unread inbox semantics.
  * - enable_inbox_digest: Enable inbox digest API payloads.
+ * - enable_inbox_digest_v1_5: Enable inbox digest v1.5 rollout behavior.
  * Unknown keys return an empty string.
  *
  * @param {FeatureFlagKey} key - Feature key to describe.
@@ -180,6 +183,8 @@ export function getFeatureFlagDescription(key: FeatureFlagKey): string {
             "Enable per-message unread model and message-level inbox semantics",
         [FEATURE_FLAGS.ENABLE_INBOX_DIGEST]:
             "Enable inbox digest API foundation for chronological unread payloads",
+        [FEATURE_FLAGS.ENABLE_INBOX_DIGEST_V1_5]:
+            "Enable inbox digest v1.5 staged rollout behavior",
     };
 
     return descriptions[key] || "";

--- a/src/lib/inbox.ts
+++ b/src/lib/inbox.ts
@@ -805,9 +805,16 @@ export async function listInboxDigest(params: {
     contextId?: string;
     contextKind?: InboxContextKind;
     limit: number;
+    useDigestV15?: boolean;
     userId: string;
 }): Promise<InboxDigestResponse> {
-    const { contextId, contextKind, limit, userId } = params;
+    const {
+        contextId,
+        contextKind,
+        limit,
+        useDigestV15 = false,
+        userId,
+    } = params;
     const isContextScoped = Boolean(contextId && contextKind);
     const upstreamLimit = isContextScoped
         ? Number.POSITIVE_INFINITY
@@ -828,7 +835,34 @@ export async function listInboxDigest(params: {
     const totalUnreadCount = isContextScoped
         ? scopedItems.reduce((total, item) => total + item.unreadCount, 0)
         : inbox.unreadCount;
-    const pagedItems = scopedItems.slice(0, limit).map((item) => ({
+    const pagedItems = buildDigestItems(scopedItems, limit, useDigestV15);
+
+    return {
+        contractVersion: inbox.contractVersion,
+        contextId,
+        contextKind,
+        items: pagedItems,
+        totalUnreadCount,
+    };
+}
+
+function buildDigestItems(
+    items: InboxItem[],
+    limit: number,
+    useDigestV15: boolean,
+): InboxDigestResponse["items"] {
+    if (useDigestV15) {
+        return buildDigestItemsV15(items, limit);
+    }
+
+    return buildDigestItemsV1(items, limit);
+}
+
+function buildDigestItemsV1(
+    items: InboxItem[],
+    limit: number,
+): InboxDigestResponse["items"] {
+    return items.slice(0, limit).map((item) => ({
         activityAt: item.latestActivityAt,
         authorAvatarUrl: item.authorAvatarUrl,
         authorLabel: item.authorLabel,
@@ -844,12 +878,13 @@ export async function listInboxDigest(params: {
         serverId: item.serverId,
         unreadCount: item.unreadCount,
     }));
+}
 
-    return {
-        contractVersion: inbox.contractVersion,
-        contextId,
-        contextKind,
-        items: pagedItems,
-        totalUnreadCount,
-    };
+function buildDigestItemsV15(
+    items: InboxItem[],
+    limit: number,
+): InboxDigestResponse["items"] {
+    // v1.5 rollout keeps the same public item contract while allowing internal
+    // implementation improvements behind a temporary feature flag.
+    return buildDigestItemsV1(items, limit);
 }


### PR DESCRIPTION
This pull request introduces a new feature flag, `enable_inbox_digest_v1_5`, to support a staged rollout of Digest API v1.5 behavior. The changes ensure that the new digest mode can be enabled selectively, is backward-compatible during rollout, and is fully test-covered. The flag and its logic are integrated across the documentation, backend, and test suites.

**Feature flag introduction and documentation:**

- Added the `enable_inbox_digest_v1_5` flag to documentation (`docs/FEATURE_FLAGS.md`), including rollout notes and usage guidance for a temporary, staged rollout of Digest API v1.5. [[1]](diffhunk://#diff-ed5555b62907f6ceeefedbe6d9431799852cc550fbce3fb29a267778e9f43fb5R15) [[2]](diffhunk://#diff-ed5555b62907f6ceeefedbe6d9431799852cc550fbce3fb29a267778e9f43fb5R35-R41)

- Updated backend setup to ensure the new flag is created in the feature flag store (`scripts/setup-appwrite.ts`).

**Backend logic and API integration:**

- Integrated the new flag into the feature flag system (`src/lib/feature-flags.ts`), including default values, descriptions, and type definitions. [[1]](diffhunk://#diff-acd264a5df31d4c4ff34d7ef3122b4240806e56be2965e86a970c4314a9cd541R13) [[2]](diffhunk://#diff-acd264a5df31d4c4ff34d7ef3122b4240806e56be2965e86a970c4314a9cd541R24) [[3]](diffhunk://#diff-acd264a5df31d4c4ff34d7ef3122b4240806e56be2965e86a970c4314a9cd541R170) [[4]](diffhunk://#diff-acd264a5df31d4c4ff34d7ef3122b4240806e56be2965e86a970c4314a9cd541R186-R187)

- Updated the inbox digest API route (`src/app/api/inbox/digest/route.ts`) to check the new flag and pass a `useDigestV15` parameter to the digest logic. [[1]](diffhunk://#diff-c48b0ddb8e543491d8d1fff480514eb3a1df25ca6854b4f1f78b2f4850e5fdc5R57-R60) [[2]](diffhunk://#diff-c48b0ddb8e543491d8d1fff480514eb3a1df25ca6854b4f1f78b2f4850e5fdc5R97)

- Refactored the `listInboxDigest` function (`src/lib/inbox.ts`) to accept `useDigestV15` and route logic accordingly, while keeping the public contract unchanged during the rollout. [[1]](diffhunk://#diff-b3b45c642b29132d86fd03f7dd57a2b4447b9f3842d5b8f93d32d26c5a356278R808-R817) [[2]](diffhunk://#diff-b3b45c642b29132d86fd03f7dd57a2b4447b9f3842d5b8f93d32d26c5a356278L831-R865) [[3]](diffhunk://#diff-b3b45c642b29132d86fd03f7dd57a2b4447b9f3842d5b8f93d32d26c5a356278R881-R889)

**Test coverage and validation:**

- Added and updated tests to verify the new flag’s presence, correct API behavior when enabled, and backward compatibility of the digest response (`src/__tests__/feature-flags.test.ts`, `src/__tests__/api-routes/inbox-digest-route.test.ts`, `src/__tests__/inbox.test.ts`). [[1]](diffhunk://#diff-2a952d76ebfdc76117c5302af8e9e69422f2d73315a03a61a3b5e6914addfeffR29-R34) [[2]](diffhunk://#diff-2a952d76ebfdc76117c5302af8e9e69422f2d73315a03a61a3b5e6914addfeffR44-R46) [[3]](diffhunk://#diff-e038224a1fbd4d84a8af7083bd858233f6cd62a8ad628f8e9a8d35da50aaf83bR25) [[4]](diffhunk://#diff-e038224a1fbd4d84a8af7083bd858233f6cd62a8ad628f8e9a8d35da50aaf83bL49-R50) [[5]](diffhunk://#diff-e038224a1fbd4d84a8af7083bd858233f6cd62a8ad628f8e9a8d35da50aaf83bR62-R88) [[6]](diffhunk://#diff-e038224a1fbd4d84a8af7083bd858233f6cd62a8ad628f8e9a8d35da50aaf83bR166) [[7]](diffhunk://#diff-ce99c3f2e5daf4a0da20863f18451795780011169b0b1a41b3d7b828c350e67dR427-R492)