### PR TITLE
Digest API v1.5 foundation phase 2

### DIFF
--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -39,6 +39,15 @@ Rollout note for `enable_inbox_digest_v1_5`:
 - Keep the public digest response contract backward-compatible while this flag is enabled.
 - Remove this flag and related branching before the 1.7 release cut; final Digest API v1 behavior should be enabled by default.
 
+Cleanup commit plan for `enable_inbox_digest_v1_5` (within 1.7):
+
+1. Merge final v1.5 digest behavior as default path in `listInboxDigest`.
+2. Remove route-level reads of `enable_inbox_digest_v1_5` and all `useDigestV15` plumbing.
+3. Delete `ENABLE_INBOX_DIGEST_V1_5` from feature-flag constants, defaults, setup seeding, and descriptions.
+4. Collapse tests to single default-on digest behavior (no temporary v1/v1.5 branching assertions).
+5. Remove this rollout note and keep only final-state digest flag documentation.
+6. Run targeted digest tests + full lint/build before release cut.
+
 ## Phase 3 Rollout Gates
 
 Use these gates before promoting unread-related flags from canary to stable:

--- a/scripts/setup-appwrite.ts
+++ b/scripts/setup-appwrite.ts
@@ -461,6 +461,36 @@ async function ensureStringArrayAttribute(
     }
 }
 
+async function updateStringAttributeSize(
+    collection: string,
+    key: string,
+    size: number,
+    required: boolean,
+) {
+    const apiPath = `/databases/${DB_ID}/collections/${collection}/attributes/string/${key}`;
+
+    const response = await fetch(`${endpoint}${apiPath}`, {
+        method: "PATCH",
+        headers: {
+            "content-type": "application/json",
+            "x-appwrite-key": apiKey,
+            "x-appwrite-project": project,
+        },
+        body: JSON.stringify({
+            required,
+            default: null,
+            size,
+        }),
+    });
+
+    if (!response.ok) {
+        const responseBody = await response.text();
+        throw new Error(
+            `HTTP ${response.status} ${response.statusText}: ${responseBody}`,
+        );
+    }
+}
+
 type IndexType = "key" | "fulltext" | "unique"; // subset used
 
 function isAttributePropagationError(message: string): boolean {
@@ -1300,35 +1330,28 @@ async function setupThreadReads() {
                 key: "reads",
             }),
     ])) as {
+        required?: boolean;
         size?: number | string;
     };
     const configuredSize = Number(readsAttribute.size ?? 0);
+    const readsRequired = Boolean(readsAttribute.required);
 
-    if (Number.isFinite(configuredSize) && configuredSize < LEN_TEXT_LARGE) {
+    if (
+        (Number.isFinite(configuredSize) && configuredSize < LEN_TEXT_LARGE) ||
+        !readsRequired
+    ) {
         try {
-            await tryVariants([
-                () =>
-                    dbAny.updateStringAttribute(
-                        DB_ID,
-                        "thread_reads",
-                        "reads",
-                        LEN_TEXT_LARGE,
-                        true,
-                    ),
-                () =>
-                    dbAny.updateStringAttribute?.({
-                        databaseId: DB_ID,
-                        collectionId: "thread_reads",
-                        key: "reads",
-                        size: LEN_TEXT_LARGE,
-                        required: true,
-                    }),
-            ]);
+            await updateStringAttributeSize(
+                "thread_reads",
+                "reads",
+                LEN_TEXT_LARGE,
+                true,
+            );
             await waitForAttribute("thread_reads", "reads");
             info("[setup] migrated thread_reads.reads to large text size");
         } catch (migrationError) {
             throw new Error(
-                `thread_reads.reads size is ${configuredSize}, below required ${LEN_TEXT_LARGE}. Run a manual schema migration before setup can continue. ${
+                `thread_reads.reads schema mismatch (size=${configuredSize}, required=${readsRequired}). Expected size=${LEN_TEXT_LARGE} and required=true. Run a manual schema migration before setup can continue. ${
                     migrationError instanceof Error
                         ? migrationError.message
                         : String(migrationError)

--- a/src/__tests__/api-routes/inbox-digest-route.test.ts
+++ b/src/__tests__/api-routes/inbox-digest-route.test.ts
@@ -30,6 +30,9 @@ vi.mock("@/lib/feature-flags", () => ({
 describe("inbox digest route", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        mockGetFeatureFlag.mockReset();
+        mockListInboxDigest.mockReset();
+        mockSession.mockReset();
         mockGetFeatureFlag.mockResolvedValue(true);
     });
 
@@ -85,6 +88,108 @@ describe("inbox digest route", () => {
             userId: "user-1",
         });
     });
+
+    it("passes digest v1 mode when v1.5 flag is disabled", async () => {
+        mockSession.mockResolvedValue({ $id: "user-1" });
+        mockGetFeatureFlag
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce(false);
+        mockListInboxDigest.mockResolvedValue({
+            contractVersion: "thread_v1",
+            contextId: undefined,
+            contextKind: undefined,
+            items: [],
+            totalUnreadCount: 0,
+        });
+
+        const response = await GET(
+            new NextRequest("http://localhost/api/inbox/digest"),
+        );
+
+        expect(response.status).toBe(200);
+        expect(mockListInboxDigest).toHaveBeenCalledWith({
+            contextId: undefined,
+            contextKind: undefined,
+            limit: 50,
+            useDigestV15: false,
+            userId: "user-1",
+        });
+    });
+
+    it.each([
+        {
+            digestEnabled: false,
+            digestV15Enabled: false,
+            expectStatus: 404,
+            expectCalled: false,
+            expectUseDigestV15: undefined,
+        },
+        {
+            digestEnabled: false,
+            digestV15Enabled: true,
+            expectStatus: 404,
+            expectCalled: false,
+            expectUseDigestV15: undefined,
+        },
+        {
+            digestEnabled: true,
+            digestV15Enabled: false,
+            expectStatus: 200,
+            expectCalled: true,
+            expectUseDigestV15: false,
+        },
+        {
+            digestEnabled: true,
+            digestV15Enabled: true,
+            expectStatus: 200,
+            expectCalled: true,
+            expectUseDigestV15: true,
+        },
+    ])(
+        "applies digest gate matrix: digest=$digestEnabled v1_5=$digestV15Enabled",
+        async ({
+            digestEnabled,
+            digestV15Enabled,
+            expectCalled,
+            expectStatus,
+            expectUseDigestV15,
+        }) => {
+            mockSession.mockResolvedValue({ $id: "user-1" });
+            if (!digestEnabled) {
+                mockGetFeatureFlag.mockResolvedValueOnce(false);
+            } else {
+                mockGetFeatureFlag
+                    .mockResolvedValueOnce(true)
+                    .mockResolvedValueOnce(digestV15Enabled);
+            }
+            mockListInboxDigest.mockResolvedValue({
+                contractVersion: "thread_v1",
+                contextId: undefined,
+                contextKind: undefined,
+                items: [],
+                totalUnreadCount: 0,
+            });
+
+            const response = await GET(
+                new NextRequest("http://localhost/api/inbox/digest"),
+            );
+
+            expect(response.status).toBe(expectStatus);
+
+            if (!expectCalled) {
+                expect(mockListInboxDigest).not.toHaveBeenCalled();
+                return;
+            }
+
+            expect(mockListInboxDigest).toHaveBeenCalledWith({
+                contextId: undefined,
+                contextKind: undefined,
+                limit: 50,
+                useDigestV15: expectUseDigestV15,
+                userId: "user-1",
+            });
+        },
+    );
 
     it("rejects invalid limit", async () => {
         mockSession.mockResolvedValue({ $id: "user-1" });

--- a/src/__tests__/inbox.test.ts
+++ b/src/__tests__/inbox.test.ts
@@ -4,11 +4,13 @@ import { listInboxDigest, listInboxItems } from "@/lib/inbox";
 
 const {
     mockGetChannelAccessForUser,
+    mockGetFeatureFlag,
     mockGetNotificationSettings,
     mockGetRelationshipMap,
     mockListDocuments,
 } = vi.hoisted(() => ({
     mockGetChannelAccessForUser: vi.fn(),
+    mockGetFeatureFlag: vi.fn(),
     mockGetNotificationSettings: vi.fn(),
     mockGetRelationshipMap: vi.fn(),
     mockListDocuments: vi.fn(),
@@ -76,10 +78,18 @@ vi.mock("@/lib/notification-settings", () => ({
     ),
 }));
 
+vi.mock("@/lib/feature-flags", () => ({
+    FEATURE_FLAGS: {
+        ENABLE_PER_MESSAGE_UNREAD: "enable_per_message_unread",
+    },
+    getFeatureFlag: mockGetFeatureFlag,
+}));
+
 describe("inbox", () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mockGetChannelAccessForUser.mockResolvedValue({ canRead: false });
+        mockGetFeatureFlag.mockResolvedValue(false);
         mockGetRelationshipMap.mockResolvedValue(new Map());
     });
 
@@ -490,4 +500,109 @@ describe("inbox", () => {
         expect(digest.items).toHaveLength(1);
         expect(digest.items[0]?.id).toBe("mention-b");
     });
+
+    it.each([
+        {
+            useDigestV15: false,
+            usePerMessageUnread: false,
+            expectedContractVersion: "thread_v1",
+            expectedFirstKind: "thread",
+            expectedTotalUnreadCount: 2,
+        },
+        {
+            useDigestV15: true,
+            usePerMessageUnread: false,
+            expectedContractVersion: "thread_v1",
+            expectedFirstKind: "mention",
+            expectedTotalUnreadCount: 2,
+        },
+        {
+            useDigestV15: false,
+            usePerMessageUnread: true,
+            expectedContractVersion: "message_v2",
+            expectedFirstKind: "thread",
+            expectedTotalUnreadCount: 3,
+        },
+        {
+            useDigestV15: true,
+            usePerMessageUnread: true,
+            expectedContractVersion: "message_v2",
+            expectedFirstKind: "mention",
+            expectedTotalUnreadCount: 3,
+        },
+    ])(
+        "applies digest and unread flags together: $useDigestV15 / $usePerMessageUnread",
+        async ({
+            expectedContractVersion,
+            expectedFirstKind,
+            expectedTotalUnreadCount,
+            useDigestV15,
+            usePerMessageUnread,
+        }) => {
+            mockGetFeatureFlag.mockResolvedValue(usePerMessageUnread);
+            mockGetChannelAccessForUser.mockResolvedValue({ canRead: true });
+            mockListDocuments.mockImplementation(
+                async (_databaseId, collectionId) => {
+                    if (collectionId === "inbox-items-collection") {
+                        return {
+                            documents: [
+                                {
+                                    $id: "mention-1",
+                                    userId: "user-1",
+                                    kind: "mention",
+                                    contextKind: "conversation",
+                                    contextId: "conversation-1",
+                                    messageId: "message-mention-1",
+                                    latestActivityAt:
+                                        "2026-03-11T11:00:00.000Z",
+                                    previewText: "mention",
+                                    authorUserId: "user-2",
+                                },
+                            ],
+                        };
+                    }
+
+                    if (collectionId === "messages-collection") {
+                        return {
+                            documents: [
+                                {
+                                    $id: "thread-1",
+                                    channelId: "channel-1",
+                                    userId: "user-3",
+                                    text: "thread",
+                                    threadMessageCount: 2,
+                                    lastThreadReplyAt:
+                                        "2026-03-11T12:00:00.000Z",
+                                    $createdAt: "2026-03-11T10:00:00.000Z",
+                                    serverId: "server-1",
+                                },
+                            ],
+                        };
+                    }
+
+                    if (collectionId === "profiles-collection") {
+                        return {
+                            documents: [
+                                { userId: "user-2", displayName: "Mention" },
+                                { userId: "user-3", displayName: "Thread" },
+                            ],
+                        };
+                    }
+
+                    return { documents: [] };
+                },
+            );
+            mockGetNotificationSettings.mockResolvedValue(null);
+
+            const digest = await listInboxDigest({
+                limit: 10,
+                useDigestV15,
+                userId: "user-1",
+            });
+
+            expect(digest.contractVersion).toBe(expectedContractVersion);
+            expect(digest.items[0]?.kind).toBe(expectedFirstKind);
+            expect(digest.totalUnreadCount).toBe(expectedTotalUnreadCount);
+        },
+    );
 });

--- a/src/lib/inbox.ts
+++ b/src/lib/inbox.ts
@@ -884,7 +884,9 @@ function buildDigestItemsV15(
     items: InboxItem[],
     limit: number,
 ): InboxDigestResponse["items"] {
-    // v1.5 rollout keeps the same public item contract while allowing internal
-    // implementation improvements behind a temporary feature flag.
-    return buildDigestItemsV1(items, limit);
+    // v1.5 keeps the same response schema but prioritizes mentions for triage.
+    const mentions = items.filter((item) => item.kind === "mention");
+    const threads = items.filter((item) => item.kind === "thread");
+
+    return buildDigestItemsV1([...mentions, ...threads], limit);
 }


### PR DESCRIPTION
This pull request introduces improvements to the inbox digest feature and its test coverage, along with a database schema migration utility. The main changes include new and expanded tests for feature flag gating and digest logic, an update to the digest v1.5 implementation to prioritize mentions, and a utility for updating string attribute properties in the database setup script. Additionally, rollout documentation for digest v1.5 has been updated with a cleanup plan.

**Inbox Digest Feature and Test Improvements:**

* Expanded test coverage in `inbox-digest-route.test.ts` to verify correct application of digest feature flags, including matrix testing of v1 and v1.5 flag combinations and their effects on API responses. [[1]](diffhunk://#diff-e038224a1fbd4d84a8af7083bd858233f6cd62a8ad628f8e9a8d35da50aaf83bR33-R35) [[2]](diffhunk://#diff-e038224a1fbd4d84a8af7083bd858233f6cd62a8ad628f8e9a8d35da50aaf83bR92-R193)
* Added comprehensive tests in `inbox.test.ts` to ensure correct behavior when combining `useDigestV15` and `usePerMessageUnread` flags, including contract version and item ordering assertions. [[1]](diffhunk://#diff-ce99c3f2e5daf4a0da20863f18451795780011169b0b1a41b3d7b828c350e67dR7-R13) [[2]](diffhunk://#diff-ce99c3f2e5daf4a0da20863f18451795780011169b0b1a41b3d7b828c350e67dR81-R92) [[3]](diffhunk://#diff-ce99c3f2e5daf4a0da20863f18451795780011169b0b1a41b3d7b828c350e67dR503-R607)

**Digest Logic Update:**

* Modified `buildDigestItemsV15` in `inbox.ts` to prioritize "mention" items before "thread" items in the digest response, aligning with v1.5 triage goals.

**Database Setup and Migration Utility:**

* Added `updateStringAttributeSize` function to `setup-appwrite.ts` for updating string attribute size and required status via API, and integrated it into the thread reads setup logic to enforce schema requirements. [[1]](diffhunk://#diff-197325a0dfc749877b560a311e4552a12cf8b2a6afffe067a45047f0ec944ed5R464-R493) [[2]](diffhunk://#diff-197325a0dfc749877b560a311e4552a12cf8b2a6afffe067a45047f0ec944ed5R1333-R1354)

**Documentation:**

* Updated the rollout note for `enable_inbox_digest_v1_5` in `FEATURE_FLAGS.md` with a detailed cleanup plan for removing the flag and consolidating related code and tests before the 1.7 release.