### PR TITLE
Bulk-catch up & triage feature implementation

### DIFF
--- a/scripts/setup-appwrite.ts
+++ b/scripts/setup-appwrite.ts
@@ -957,6 +957,11 @@ async function setupFeatureFlags() {
         enabled: false,
         key: "enable_inbox_digest_v1_5",
     });
+    await ensureFeatureFlagDocument({
+        description: "Enable bulk catch-up UI for inbox triage actions",
+        enabled: false,
+        key: "enable_bulk_catch_up",
+    });
 }
 
 async function ensureFeatureFlagDocument(params: {

--- a/src/__tests__/inbox-client.test.ts
+++ b/src/__tests__/inbox-client.test.ts
@@ -3,59 +3,145 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { listInboxDigest } from "@/lib/inbox-client";
+import { listInboxDigest, markInboxScopeRead } from "@/lib/inbox-client";
 
 describe("inbox-client", () => {
     beforeEach(() => {
         vi.restoreAllMocks();
     });
 
-    it("requests inbox digest with scoped query parameters", async () => {
-        vi.stubGlobal(
-            "fetch",
-            vi.fn(
-                async () =>
-                    ({
-                        json: async () => ({
-                            contractVersion: "message_v2",
-                            contextId: "conversation-1",
-                            contextKind: "conversation",
-                            items: [],
-                            totalUnreadCount: 0,
-                        }),
-                        ok: true,
-                    }) as Response,
-            ),
-        );
+    describe("listInboxDigest", () => {
+        it("requests inbox digest with scoped query parameters", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(
+                    async () =>
+                        ({
+                            json: async () => ({
+                                contractVersion: "message_v2",
+                                contextId: "conversation-1",
+                                contextKind: "conversation",
+                                items: [],
+                                totalUnreadCount: 0,
+                            }),
+                            ok: true,
+                        }) as Response,
+                ),
+            );
 
-        const result = await listInboxDigest({
-            contextId: "conversation-1",
-            contextKind: "conversation",
-            limit: 25,
+            const result = await listInboxDigest({
+                contextId: "conversation-1",
+                contextKind: "conversation",
+                limit: 25,
+            });
+
+            expect(fetch).toHaveBeenCalledWith(
+                "/api/inbox/digest?contextId=conversation-1&contextKind=conversation&limit=25",
+            );
+            expect(result.contractVersion).toBe("message_v2");
         });
 
-        expect(fetch).toHaveBeenCalledWith(
-            "/api/inbox/digest?contextId=conversation-1&contextKind=conversation&limit=25",
-        );
-        expect(result.contractVersion).toBe("message_v2");
+        it("throws with server-provided message when digest request fails", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(
+                    async () =>
+                        ({
+                            json: async () => ({
+                                error: "Inbox digest unavailable",
+                            }),
+                            ok: false,
+                        }) as Response,
+                ),
+            );
+
+            await expect(listInboxDigest()).rejects.toThrow(
+                "Inbox digest unavailable",
+            );
+        });
     });
 
-    it("throws with server-provided message when digest request fails", async () => {
-        vi.stubGlobal(
-            "fetch",
-            vi.fn(
+    describe("markInboxScopeRead", () => {
+        it("marks all inbox items as read", async () => {
+            const fetchMock = vi.fn(
                 async () =>
                     ({
-                        json: async () => ({
-                            error: "Inbox digest unavailable",
-                        }),
-                        ok: false,
+                        ok: true,
                     }) as Response,
-            ),
-        );
+            );
+            vi.stubGlobal("fetch", fetchMock);
 
-        await expect(listInboxDigest()).rejects.toThrow(
-            "Inbox digest unavailable",
-        );
+            await markInboxScopeRead("all");
+
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+            expect(fetchMock).toHaveBeenCalledWith(
+                "/api/inbox",
+                expect.objectContaining({
+                    method: "PATCH",
+                    body: JSON.stringify({
+                        action: "mark-all-read",
+                        contextKind: "channel",
+                    }),
+                }),
+            );
+            expect(fetchMock).toHaveBeenCalledWith(
+                "/api/inbox",
+                expect.objectContaining({
+                    method: "PATCH",
+                    body: JSON.stringify({
+                        action: "mark-all-read",
+                        contextKind: "conversation",
+                    }),
+                }),
+            );
+        });
+
+        it("marks only direct messages as read when scope is direct", async () => {
+            const fetchMock = vi.fn(
+                async () =>
+                    ({
+                        ok: true,
+                    }) as Response,
+            );
+            vi.stubGlobal("fetch", fetchMock);
+
+            await markInboxScopeRead("direct");
+
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(fetchMock).toHaveBeenCalledWith(
+                "/api/inbox",
+                expect.objectContaining({
+                    method: "PATCH",
+                    body: JSON.stringify({
+                        action: "mark-all-read",
+                        contextKind: "conversation",
+                    }),
+                }),
+            );
+        });
+
+        it("marks only server channels as read when scope is server", async () => {
+            const fetchMock = vi.fn(
+                async () =>
+                    ({
+                        ok: true,
+                    }) as Response,
+            );
+            vi.stubGlobal("fetch", fetchMock);
+
+            await markInboxScopeRead("server");
+
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(fetchMock).toHaveBeenCalledWith(
+                "/api/inbox",
+                expect.objectContaining({
+                    method: "PATCH",
+                    body: JSON.stringify({
+                        action: "mark-all-read",
+                        contextKind: "channel",
+                    }),
+                }),
+            );
+        });
     });
 });

--- a/src/app/chat/components/ConversationList.tsx
+++ b/src/app/chat/components/ConversationList.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import type { Conversation, InboxItem, InboxListResponse } from "@/lib/types";
 import { toast } from "sonner";
+import { InboxToolbar } from "./InboxToolbar";
 
 type SidebarMode = "chats" | "inbox" | "mentions";
 
@@ -126,6 +127,10 @@ type ConversationListProps = {
     inboxLoading?: boolean;
     inboxContractVersion?: InboxListResponse["contractVersion"];
     conversationUnreadStateById?: Record<string, ConversationUnreadState>;
+    inboxBulkLoading?: "all" | "direct" | "server" | null;
+    onMarkInboxScopeRead?: (
+        scope: "all" | "direct" | "server",
+    ) => Promise<void>;
 };
 
 export function ConversationList({
@@ -141,6 +146,8 @@ export function ConversationList({
     inboxLoading = false,
     inboxContractVersion = "thread_v1",
     conversationUnreadStateById = {},
+    inboxBulkLoading = null,
+    onMarkInboxScopeRead,
 }: ConversationListProps) {
     const router = useRouter();
     const {
@@ -603,57 +610,72 @@ export function ConversationList({
             {/* Conversations List */}
             <div className="flex-1 overflow-y-auto">
                 {sidebarMode === "inbox" ? (
-                    <fieldset className="grid grid-cols-4 gap-1 border-0 border-border border-b p-2">
-                        <legend className="sr-only">Inbox filter</legend>
-                        <Button
-                            aria-pressed={inboxFilter === "all"}
-                            className="rounded-lg"
-                            onClick={() => setInboxFilter("all")}
-                            size="sm"
-                            type="button"
-                            variant={
-                                inboxFilter === "all" ? "default" : "ghost"
-                            }
-                        >
-                            All
-                        </Button>
-                        <Button
-                            aria-pressed={inboxFilter === "mentions"}
-                            className="rounded-lg"
-                            onClick={() => setInboxFilter("mentions")}
-                            size="sm"
-                            type="button"
-                            variant={
-                                inboxFilter === "mentions" ? "default" : "ghost"
-                            }
-                        >
-                            Mentions
-                        </Button>
-                        <Button
-                            aria-pressed={inboxFilter === "direct"}
-                            className="rounded-lg"
-                            onClick={() => setInboxFilter("direct")}
-                            size="sm"
-                            type="button"
-                            variant={
-                                inboxFilter === "direct" ? "default" : "ghost"
-                            }
-                        >
-                            Direct
-                        </Button>
-                        <Button
-                            aria-pressed={inboxFilter === "server"}
-                            className="rounded-lg"
-                            onClick={() => setInboxFilter("server")}
-                            size="sm"
-                            type="button"
-                            variant={
-                                inboxFilter === "server" ? "default" : "ghost"
-                            }
-                        >
-                            Servers
-                        </Button>
-                    </fieldset>
+                    <>
+                        <fieldset className="grid grid-cols-4 gap-1 border-0 border-border border-b p-2">
+                            <legend className="sr-only">Inbox filter</legend>
+                            <Button
+                                aria-pressed={inboxFilter === "all"}
+                                className="rounded-lg"
+                                onClick={() => setInboxFilter("all")}
+                                size="sm"
+                                type="button"
+                                variant={
+                                    inboxFilter === "all" ? "default" : "ghost"
+                                }
+                            >
+                                All
+                            </Button>
+                            <Button
+                                aria-pressed={inboxFilter === "mentions"}
+                                className="rounded-lg"
+                                onClick={() => setInboxFilter("mentions")}
+                                size="sm"
+                                type="button"
+                                variant={
+                                    inboxFilter === "mentions"
+                                        ? "default"
+                                        : "ghost"
+                                }
+                            >
+                                Mentions
+                            </Button>
+                            <Button
+                                aria-pressed={inboxFilter === "direct"}
+                                className="rounded-lg"
+                                onClick={() => setInboxFilter("direct")}
+                                size="sm"
+                                type="button"
+                                variant={
+                                    inboxFilter === "direct"
+                                        ? "default"
+                                        : "ghost"
+                                }
+                            >
+                                Direct
+                            </Button>
+                            <Button
+                                aria-pressed={inboxFilter === "server"}
+                                className="rounded-lg"
+                                onClick={() => setInboxFilter("server")}
+                                size="sm"
+                                type="button"
+                                variant={
+                                    inboxFilter === "server"
+                                        ? "default"
+                                        : "ghost"
+                                }
+                            >
+                                Servers
+                            </Button>
+                        </fieldset>
+                        {onMarkInboxScopeRead && (
+                            <InboxToolbar
+                                bulkLoading={inboxBulkLoading}
+                                onMarkScopeRead={onMarkInboxScopeRead}
+                                unreadCount={inboxUnreadCount}
+                            />
+                        )}
+                    </>
                 ) : null}
 
                 {sidebarMode === "chats" &&

--- a/src/app/chat/components/InboxToolbar.tsx
+++ b/src/app/chat/components/InboxToolbar.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { InboxScope } from "@/lib/inbox-client";
+import { toast } from "sonner";
+
+interface InboxToolbarProps {
+    bulkLoading: InboxScope | null;
+    onMarkScopeRead: (scope: InboxScope) => Promise<void>;
+    unreadCount: number;
+}
+
+export function InboxToolbar({
+    bulkLoading,
+    onMarkScopeRead,
+    unreadCount,
+}: InboxToolbarProps) {
+    const [open, setOpen] = useState(false);
+
+    const handleMarkRead = async (scope: InboxScope) => {
+        try {
+            await onMarkScopeRead(scope);
+            const message =
+                scope === "all"
+                    ? "Marked all conversations as read"
+                    : scope === "direct"
+                      ? "Marked all direct messages as read"
+                      : "Marked all servers as read";
+            toast.success(message);
+        } catch {
+            toast.error("Failed to mark as read");
+        }
+        setOpen(false);
+    };
+
+    const isLoading = bulkLoading !== null;
+    const loadingLabel =
+        bulkLoading === "all"
+            ? "Marking all as read..."
+            : bulkLoading === "direct"
+              ? "Marking DMs as read..."
+              : bulkLoading === "server"
+                ? "Marking servers as read..."
+                : "";
+
+    return (
+        <div className="flex items-center justify-between border-b border-border/60 p-2">
+            <span className="text-xs text-muted-foreground">
+                {unreadCount > 0
+                    ? `${unreadCount} unread item${unreadCount === 1 ? "" : "s"}`
+                    : "All caught up"}
+            </span>
+            <DropdownMenu open={open} onOpenChange={setOpen}>
+                <DropdownMenuTrigger asChild>
+                    <Button
+                        disabled={isLoading || unreadCount === 0}
+                        size="sm"
+                        variant="outline"
+                    >
+                        {isLoading ? (
+                            <>
+                                <Loader2 className="mr-2 size-3.5 animate-spin" />
+                                {loadingLabel}
+                            </>
+                        ) : (
+                            <>
+                                <Check className="mr-2 size-3.5" />
+                                Mark as read
+                            </>
+                        )}
+                    </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                    <DropdownMenuItem
+                        disabled={isLoading}
+                        onClick={() => void handleMarkRead("all")}
+                    >
+                        Mark all as read
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                        disabled={isLoading}
+                        onClick={() => void handleMarkRead("direct")}
+                    >
+                        Mark all DMs as read
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                        disabled={isLoading}
+                        onClick={() => void handleMarkRead("server")}
+                    >
+                        Mark all servers as read
+                    </DropdownMenuItem>
+                </DropdownMenuContent>
+            </DropdownMenu>
+        </div>
+    );
+}

--- a/src/app/chat/hooks/useInbox.ts
+++ b/src/app/chat/hooks/useInbox.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { getEnvConfig } from "@/lib/appwrite-core";
@@ -8,6 +8,8 @@ import {
     listInbox,
     markInboxContextRead,
     markInboxItemsRead,
+    markInboxScopeRead,
+    type InboxScope,
 } from "@/lib/inbox-client";
 import { getSharedClient, trackSubscription } from "@/lib/realtime-pool";
 import type {
@@ -115,6 +117,7 @@ export function useInbox(userId: string | null) {
     const queryClient = useQueryClient();
     const env = getEnvConfig();
     const isEnabled = Boolean(userId);
+    const [bulkLoading, setBulkLoading] = useState<InboxScope | null>(null);
 
     const {
         data = EMPTY_INBOX,
@@ -299,6 +302,23 @@ export function useInbox(userId: string | null) {
         [refetch, updateInboxCache],
     );
 
+    const markScopeRead = useCallback(
+        async (scope: InboxScope) => {
+            setBulkLoading(scope);
+
+            updateInboxCache(() => EMPTY_INBOX);
+
+            try {
+                await markInboxScopeRead(scope);
+            } catch {
+                await refetch();
+            } finally {
+                setBulkLoading(null);
+            }
+        },
+        [refetch, updateInboxCache],
+    );
+
     const getContextSummary = useCallback(
         (contextKind: InboxContextKind, contextId: string) =>
             contextSummaryByKey.get(
@@ -308,6 +328,7 @@ export function useInbox(userId: string | null) {
     );
 
     return {
+        bulkLoading,
         contractVersion: data.contractVersion,
         counts: data.counts,
         error: formatInboxError(error),
@@ -316,6 +337,7 @@ export function useInbox(userId: string | null) {
         loading: isEnabled ? isLoading : false,
         markContextRead,
         markItemRead,
+        markScopeRead,
         refresh: refetch,
         summaries: contextSummaries,
         unreadCount: data.unreadCount,

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1803,6 +1803,8 @@ export default function ChatPage() {
                             loading={conversationsApi.loading}
                             inboxItems={inboxApi.items}
                             inboxLoading={inboxApi.loading}
+                            inboxBulkLoading={inboxApi.bulkLoading}
+                            onMarkInboxScopeRead={inboxApi.markScopeRead}
                             onMuteConversation={(
                                 conversationId,
                                 conversationName,

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -11,6 +11,7 @@ export const FEATURE_FLAGS = {
     ENABLE_PER_MESSAGE_UNREAD: "enable_per_message_unread",
     ENABLE_INBOX_DIGEST: "enable_inbox_digest",
     ENABLE_INBOX_DIGEST_V1_5: "enable_inbox_digest_v1_5",
+    ENABLE_BULK_CATCH_UP: "enable_bulk_catch_up",
 } as const;
 
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS];
@@ -22,6 +23,7 @@ const DEFAULT_FLAGS: Record<FeatureFlagKey, boolean> = {
     [FEATURE_FLAGS.ENABLE_PER_MESSAGE_UNREAD]: false,
     [FEATURE_FLAGS.ENABLE_INBOX_DIGEST]: false,
     [FEATURE_FLAGS.ENABLE_INBOX_DIGEST_V1_5]: false,
+    [FEATURE_FLAGS.ENABLE_BULK_CATCH_UP]: false,
 };
 
 // Cache for feature flags to reduce database calls
@@ -185,6 +187,8 @@ export function getFeatureFlagDescription(key: FeatureFlagKey): string {
             "Enable inbox digest API foundation for chronological unread payloads",
         [FEATURE_FLAGS.ENABLE_INBOX_DIGEST_V1_5]:
             "Enable inbox digest v1.5 staged rollout behavior",
+        [FEATURE_FLAGS.ENABLE_BULK_CATCH_UP]:
+            "Enable bulk catch-up UI for inbox triage actions",
     };
 
     return descriptions[key] || "";

--- a/src/lib/inbox-client.ts
+++ b/src/lib/inbox-client.ts
@@ -149,6 +149,27 @@ export async function markInboxContextRead(params?: {
 }
 
 /**
+ * Marks all inbox items in a scope as read.
+ *
+ * @param {InboxScope} scope - The scope: "all", "direct" (DMs), or "server" (channels).
+ * @returns {Promise<void>} The return value.
+ */
+export async function markInboxScopeRead(scope: InboxScope): Promise<void> {
+    const contextKinds: InboxContextKind[] =
+        scope === "direct"
+            ? ["conversation"]
+            : scope === "server"
+              ? ["channel"]
+              : ["channel", "conversation"];
+
+    const promises = contextKinds.map((contextKind) =>
+        markInboxContextRead({ contextKind }),
+    );
+
+    await Promise.all(promises);
+}
+
+/**
  * Lists inbox digest.
  *
  * @param {{ contextId?: string | undefined; contextKind?: 'channel' | 'conversation' | undefined; limit?: number | undefined; } | undefined} params - The params value, if provided.

--- a/src/lib/inbox.ts
+++ b/src/lib/inbox.ts
@@ -856,6 +856,9 @@ export async function listInboxDigest(params: {
 
     return {
         contractVersion: inbox.contractVersion,
+        navigationFallback: "context_catch_up",
+        ordering: useDigestV15 ? "triage_priority" : "newest_first",
+        presentation: "flat",
         contextId,
         contextKind,
         items: pagedItems,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -193,6 +193,9 @@ export type InboxDigestItem = {
 
 export type InboxDigestResponse = {
     contractVersion: InboxContractVersion;
+    navigationFallback: "context_catch_up";
+    ordering: "newest_first" | "triage_priority";
+    presentation: "flat";
     contextId?: string;
     contextKind?: InboxContextKind;
     items: InboxDigestItem[];


### PR DESCRIPTION
This pull request introduces a new "bulk catch-up" feature for the inbox, allowing users to mark all inbox items as read in bulk, either for all conversations, direct messages, or server channels. The update includes backend support, UI components, feature flag integration, and comprehensive tests.

**Bulk catch-up feature implementation:**

* Added a new function `markInboxScopeRead` in `inbox-client.ts` to mark all inbox items as read by scope (all, direct, server), and integrated it into the `useInbox` hook for state management and UI feedback. [[1]](diffhunk://#diff-e8545b775ee61c1d3087f24667e1fd0adaf5fdacc77b359a55c6027927b92c2dR151-R171) [[2]](diffhunk://#diff-511f2d5c7d09cc532e52d16400983bb2fd347eae59c0e4e3f557b652a09f94ceL3-R12) [[3]](diffhunk://#diff-511f2d5c7d09cc532e52d16400983bb2fd347eae59c0e4e3f557b652a09f94ceR120) [[4]](diffhunk://#diff-511f2d5c7d09cc532e52d16400983bb2fd347eae59c0e4e3f557b652a09f94ceR305-R321) [[5]](diffhunk://#diff-511f2d5c7d09cc532e52d16400983bb2fd347eae59c0e4e3f557b652a09f94ceR331) [[6]](diffhunk://#diff-511f2d5c7d09cc532e52d16400983bb2fd347eae59c0e4e3f557b652a09f94ceR340)
* Created the `InboxToolbar` component to provide a dropdown UI for bulk marking inbox items as read, with loading states and toast notifications. This component is conditionally rendered in the inbox view of the `ConversationList`. [[1]](diffhunk://#diff-3d2926901bda82a15ffff7ee55b052528a6aac634e2b9d2605b5dddd4727dbe8R1-R104) [[2]](diffhunk://#diff-32e3c66f64d44c1c4aeba618456854aae794e840981578fb3a144187530dff7bR39) [[3]](diffhunk://#diff-32e3c66f64d44c1c4aeba618456854aae794e840981578fb3a144187530dff7bR130-R133) [[4]](diffhunk://#diff-32e3c66f64d44c1c4aeba618456854aae794e840981578fb3a144187530dff7bR149-R150) [[5]](diffhunk://#diff-32e3c66f64d44c1c4aeba618456854aae794e840981578fb3a144187530dff7bR613) [[6]](diffhunk://#diff-32e3c66f64d44c1c4aeba618456854aae794e840981578fb3a144187530dff7bL651-R678) [[7]](diffhunk://#diff-d27a8260c8576637afe3b96a898425933d108ffa8cf9c854d6544f9752e81f2fR1806-R1807)

**Feature flag integration:**

* Added a new feature flag `enable_bulk_catch_up` in both the backend setup script and the frontend feature flag system, including descriptions and default values. [[1]](diffhunk://#diff-197325a0dfc749877b560a311e4552a12cf8b2a6afffe067a45047f0ec944ed5R960-R964) [[2]](diffhunk://#diff-acd264a5df31d4c4ff34d7ef3122b4240806e56be2965e86a970c4314a9cd541R14) [[3]](diffhunk://#diff-acd264a5df31d4c4ff34d7ef3122b4240806e56be2965e86a970c4314a9cd541R26) [[4]](diffhunk://#diff-acd264a5df31d4c4ff34d7ef3122b4240806e56be2965e86a970c4314a9cd541R190-R191)

**Testing enhancements:**

* Added unit tests for `markInboxScopeRead` in the `inbox-client` test suite to ensure correct API calls for each scope. [[1]](diffhunk://#diff-b0addc2157456eb43b2b1bb510885551097d24f44bb7d7f6e92e69d94f11adf8L6-R13) [[2]](diffhunk://#diff-b0addc2157456eb43b2b1bb510885551097d24f44bb7d7f6e92e69d94f11adf8R63-R147)

**API and type changes:**

* Updated the inbox digest API and types to include new fields for navigation fallback, ordering, and presentation, supporting the new triage and bulk actions. [[1]](diffhunk://#diff-b3b45c642b29132d86fd03f7dd57a2b4447b9f3842d5b8f93d32d26c5a356278R859-R861) [[2]](diffhunk://#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5R196-R198)

These changes collectively enable a smoother and more efficient inbox triage experience, with robust backend, frontend, and testing support for the new bulk catch-up capability.