### PR TITLE
Nitpick feature: Multiple roles can access same category

### DIFF
--- a/scripts/setup-appwrite.ts
+++ b/scripts/setup-appwrite.ts
@@ -661,7 +661,12 @@ async function setupCategories() {
     await ensureStringAttribute("categories", "serverId", LEN_ID, true);
     await ensureStringAttribute("categories", "name", LEN_ID, true);
     await ensureStringAttribute("categories", "createdBy", LEN_ID, false);
-    await ensureStringAttribute("categories", "requiredRoleId", LEN_ID, false);
+    await ensureStringArrayAttribute(
+        "categories",
+        "allowedRoleIds",
+        LEN_ID,
+        false,
+    );
     await ensureIntegerAttribute("categories", "position", true, 0, 0);
     await ensureIndex("categories", "idx_serverId", "key", ["serverId"]);
     await ensureIndex("categories", "idx_position", "key", ["position"]);

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -114,14 +114,18 @@ export async function GET(request: NextRequest) {
         const isAdmin = auth.access.permissions?.administrator ?? false;
 
         const accessibleCategories = categories.documents.filter((category) => {
-            const requiredRoleId = category.requiredRoleId;
-            if (!requiredRoleId) {
+            const allowedRoleIds = category.allowedRoleIds as
+                | string[]
+                | undefined;
+            if (!allowedRoleIds || allowedRoleIds.length === 0) {
                 return true;
             }
             if (isOwner || isAdmin) {
                 return true;
             }
-            return userRoleIds.includes(requiredRoleId);
+            return allowedRoleIds.some((roleId) =>
+                userRoleIds.includes(roleId),
+            );
         });
 
         return NextResponse.json({ categories: accessibleCategories });
@@ -189,7 +193,7 @@ export async function PUT(request: NextRequest) {
             categoryId?: string;
             name?: string;
             position?: number;
-            requiredRoleId?: string | null;
+            allowedRoleIds?: string[] | null;
         };
 
         if (!body.categoryId) {
@@ -212,7 +216,8 @@ export async function PUT(request: NextRequest) {
             return auth.response;
         }
 
-        const updateData: Record<string, string | number | null> = {};
+        const updateData: Record<string, string | number | string[] | null> =
+            {};
         if (body.name !== undefined) {
             const nextName = body.name.trim();
             if (!nextName) {
@@ -232,11 +237,11 @@ export async function PUT(request: NextRequest) {
             }
             updateData.position = body.position;
         }
-        if (body.requiredRoleId !== undefined) {
-            updateData.requiredRoleId =
-                body.requiredRoleId === null || body.requiredRoleId === ""
+        if (body.allowedRoleIds !== undefined) {
+            updateData.allowedRoleIds =
+                body.allowedRoleIds === null || body.allowedRoleIds.length === 0
                     ? null
-                    : body.requiredRoleId;
+                    : body.allowedRoleIds;
         }
 
         if (Object.keys(updateData).length === 0) {

--- a/src/components/category-settings-panel.tsx
+++ b/src/components/category-settings-panel.tsx
@@ -292,13 +292,11 @@ export function CategorySettingsPanel({
         }
     }
 
-    async function saveRequiredRole(
+    async function saveAllowedRoles(
         categoryId: string,
-        requiredRoleId: string,
+        allowedRoleIds: string[],
     ) {
         const previousCategories = categories;
-        const normalizedRoleId =
-            requiredRoleId === "none" ? null : requiredRoleId;
 
         setCategoryPending([categoryId], true);
         setCategories((currentValue) =>
@@ -306,7 +304,7 @@ export function CategorySettingsPanel({
                 category.$id === categoryId
                     ? {
                           ...category,
-                          requiredRoleId: normalizedRoleId ?? undefined,
+                          allowedRoleIds,
                       }
                     : category,
             ),
@@ -318,7 +316,7 @@ export function CategorySettingsPanel({
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
                     categoryId,
-                    requiredRoleId: normalizedRoleId,
+                    allowedRoleIds,
                 }),
             });
 
@@ -763,41 +761,66 @@ export function CategorySettingsPanel({
                                 {sortedRoles.length > 0 && (
                                     <div className="flex items-center gap-2 rounded-md bg-muted/30 px-3 py-2">
                                         <Shield className="h-4 w-4 text-muted-foreground" />
-                                        <Select
-                                            disabled={pendingCategoryIds.includes(
-                                                category.$id,
-                                            )}
-                                            onValueChange={(value) =>
-                                                void saveRequiredRole(
-                                                    category.$id,
-                                                    value,
-                                                )
-                                            }
-                                            value={
-                                                category.requiredRoleId ??
-                                                "none"
-                                            }
-                                        >
-                                            <SelectTrigger className="w-56">
-                                                <SelectValue placeholder="Access control" />
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                                <SelectItem value="none">
-                                                    Everyone can access
-                                                </SelectItem>
-                                                {sortedRoles.map((role) => (
-                                                    <SelectItem
+                                        <div className="flex flex-wrap gap-1">
+                                            {sortedRoles.map((role) => {
+                                                const isSelected =
+                                                    category.allowedRoleIds?.includes(
+                                                        role.$id,
+                                                    ) ?? false;
+                                                return (
+                                                    <button
+                                                        disabled={pendingCategoryIds.includes(
+                                                            category.$id,
+                                                        )}
                                                         key={role.$id}
-                                                        value={role.$id}
+                                                        onClick={() => {
+                                                            const current =
+                                                                category.allowedRoleIds ||
+                                                                [];
+                                                            const newAllowed =
+                                                                isSelected
+                                                                    ? current.filter(
+                                                                          (
+                                                                              id,
+                                                                          ) =>
+                                                                              id !==
+                                                                              role.$id,
+                                                                      )
+                                                                    : [
+                                                                          ...current,
+                                                                          role.$id,
+                                                                      ];
+                                                            void saveAllowedRoles(
+                                                                category.$id,
+                                                                newAllowed,
+                                                            );
+                                                        }}
+                                                        type="button"
+                                                        className={`rounded-full border px-2 py-0.5 text-xs transition-colors ${
+                                                            isSelected
+                                                                ? "border-primary bg-primary/10 text-primary"
+                                                                : "border-border bg-background text-muted-foreground hover:border-primary/50"
+                                                        }`}
                                                     >
-                                                        {role.name} only
-                                                    </SelectItem>
-                                                ))}
-                                            </SelectContent>
-                                        </Select>
-                                        <span className="text-xs text-muted-foreground">
-                                            {category.requiredRoleId
-                                                ? `Restricted to ${roles.find((r) => r.$id === category.requiredRoleId)?.name || "a role"}`
+                                                        {role.name}
+                                                    </button>
+                                                );
+                                            })}
+                                        </div>
+                                        <span className="ml-auto text-xs text-muted-foreground">
+                                            {category.allowedRoleIds &&
+                                            category.allowedRoleIds.length > 0
+                                                ? `Restricted to ${category.allowedRoleIds
+                                                      .map(
+                                                          (id) =>
+                                                              roles.find(
+                                                                  (r) =>
+                                                                      r.$id ===
+                                                                      id,
+                                                              )?.name ||
+                                                              "a role",
+                                                      )
+                                                      .join(", ")}`
                                                 : "Visible to all members"}
                                         </span>
                                     </div>

--- a/src/lib/server-channel-access.ts
+++ b/src/lib/server-channel-access.ts
@@ -277,12 +277,14 @@ async function hasAccessToCategory(
         categoryId,
     );
 
-    const requiredRoleId = category.requiredRoleId;
-    if (!requiredRoleId) {
+    const allowedRoleIds = category.allowedRoleIds as string[] | undefined;
+    if (!allowedRoleIds || allowedRoleIds.length === 0) {
         return true;
     }
 
-    return serverAccess.roleIds.includes(requiredRoleId);
+    return allowedRoleIds.some((roleId) =>
+        serverAccess.roleIds.includes(roleId),
+    );
 }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -87,7 +87,7 @@ export type ChannelCategory = {
     name: string;
     position: number;
     createdBy?: string;
-    requiredRoleId?: string;
+    allowedRoleIds?: string[];
     $createdAt: string;
     $updatedAt?: string;
 };


### PR DESCRIPTION
This pull request updates the category access control system to support multiple allowed roles per category, rather than just a single required role. The core change is the replacement of the `requiredRoleId` field with an `allowedRoleIds` array throughout the backend, API, and frontend, allowing categories to be restricted to any combination of roles instead of just one. The UI for editing allowed roles is also updated to support multi-selection.

**Access Control Model Update:**

* Replaced the `requiredRoleId` field with an `allowedRoleIds` array in the category schema, API request/response types, and database setup logic, enabling categories to be accessible by multiple roles. [[1]](diffhunk://#diff-197325a0dfc749877b560a311e4552a12cf8b2a6afffe067a45047f0ec944ed5L664-R669) [[2]](diffhunk://#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5L90-R90) [[3]](diffhunk://#diff-dc283dd04aec5f03451f31fc50ee00e5270b29ecc173db215925c2d23f023565L192-R196) [[4]](diffhunk://#diff-dc283dd04aec5f03451f31fc50ee00e5270b29ecc173db215925c2d23f023565L215-R220) [[5]](diffhunk://#diff-dc283dd04aec5f03451f31fc50ee00e5270b29ecc173db215925c2d23f023565L235-R244)

* Updated access checks in both the API (`src/app/api/categories/route.ts`) and server-side logic (`src/lib/server-channel-access.ts`) to use the new `allowedRoleIds` array, granting access if the user has any of the allowed roles. [[1]](diffhunk://#diff-dc283dd04aec5f03451f31fc50ee00e5270b29ecc173db215925c2d23f023565L117-R128) [[2]](diffhunk://#diff-1c79d3c9462affa5b6babc899d5d9c5e48de4abe9ed3912297d1e13a910bfb24L280-R287)

**Frontend/UI Changes:**

* Refactored the category settings UI to allow selecting multiple roles for category access, replacing the single-select dropdown with a multi-select button group and updating the display logic accordingly.

* Updated the category settings logic and API calls to handle the new `allowedRoleIds` array, including updating and saving multiple allowed roles per category. [[1]](diffhunk://#diff-a7a504a00bda5b859bc2b7cb455a7bd5f937516fa3f6885ae4ac659e6cff2becL295-R307) [[2]](diffhunk://#diff-a7a504a00bda5b859bc2b7cb455a7bd5f937516fa3f6885ae4ac659e6cff2becL321-R319)