### PR TITLE
Migrate Appwrite subscriptions to Realtime helpers

### DIFF
--- a/src/__tests__/chat-hooks-thread-read-wiring.test.tsx
+++ b/src/__tests__/chat-hooks-thread-read-wiring.test.tsx
@@ -74,8 +74,8 @@ vi.mock("@/lib/thread-pin-client", () => ({
 }));
 
 vi.mock("@/lib/realtime-pool", () => ({
-    getSharedClient: vi.fn(() => ({
-        subscribe: vi.fn(() => vi.fn()),
+    getSharedRealtime: vi.fn(() => ({
+        subscribe: vi.fn(async () => ({ close: vi.fn() })),
     })),
     trackSubscription: vi.fn(() => vi.fn()),
 }));

--- a/src/__tests__/chat-hooks-useConversations.test.ts
+++ b/src/__tests__/chat-hooks-useConversations.test.ts
@@ -34,11 +34,11 @@ vi.mock("@/app/chat/hooks/useStatusSubscription", () => ({
     })),
 }));
 
-const mockSubscribe = vi.hoisted(() => vi.fn(() => vi.fn()));
+const mockSubscribe = vi.hoisted(() => vi.fn(async () => ({ close: vi.fn() })));
 const mockTrackSubscription = vi.hoisted(() => vi.fn(() => vi.fn()));
 
 vi.mock("@/lib/realtime-pool", () => ({
-    getSharedClient: vi.fn(() => ({
+    getSharedRealtime: vi.fn(() => ({
         subscribe: mockSubscribe,
     })),
     trackSubscription: mockTrackSubscription,
@@ -93,7 +93,7 @@ describe("useConversations", () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
-        mockSubscribe.mockReturnValue(vi.fn());
+        mockSubscribe.mockResolvedValue({ close: vi.fn() });
         mockTrackSubscription.mockReturnValue(vi.fn());
     });
 

--- a/src/__tests__/chat-hooks-useDirectMessages.test.ts
+++ b/src/__tests__/chat-hooks-useDirectMessages.test.ts
@@ -80,8 +80,8 @@ vi.mock("@/lib/thread-pin-client", () => ({
 }));
 
 vi.mock("@/lib/realtime-pool", () => ({
-    getSharedClient: vi.fn(() => ({
-        subscribe: vi.fn(() => vi.fn()),
+    getSharedRealtime: vi.fn(() => ({
+        subscribe: vi.fn(async () => ({ close: vi.fn() })),
     })),
     trackSubscription: vi.fn(() => vi.fn()),
 }));

--- a/src/__tests__/custom-emojis.test.ts
+++ b/src/__tests__/custom-emojis.test.ts
@@ -39,8 +39,8 @@ global.URL.revokeObjectURL = vi.fn();
 
 // Mock realtime pool
 vi.mock("@/lib/realtime-pool", () => ({
-	getSharedClient: vi.fn(() => ({
-		subscribe: vi.fn(() => vi.fn()),
+	getSharedRealtime: vi.fn(() => ({
+		subscribe: vi.fn(async () => ({ close: vi.fn() })),
 	})),
 	trackSubscription: vi.fn(() => vi.fn()),
 }));
@@ -195,19 +195,23 @@ describe("Custom Emojis - Realtime Synchronization", () => {
 	it("should have realtime pool utilities", async () => {
 		const realtimePool = await import("@/lib/realtime-pool");
 		
-		expect(typeof realtimePool.getSharedClient).toBe("function");
+		expect(typeof realtimePool.getSharedRealtime).toBe("function");
 		expect(typeof realtimePool.trackSubscription).toBe("function");
 	});
 
-	it("should mock realtime client subscription", () => {
+	it("should mock realtime client subscription", async () => {
 		const mockClient = {
-			subscribe: vi.fn(() => vi.fn()),
+			subscribe: vi.fn(async () => ({ close: vi.fn() })),
 		};
 
-		const unsubscribe = mockClient.subscribe("test-channel", () => {});
+		const subscription = mockClient.subscribe("test-channel", () => {});
 		
 		expect(mockClient.subscribe).toHaveBeenCalledWith("test-channel", expect.any(Function));
-		expect(typeof unsubscribe).toBe("function");
+		await expect(subscription).resolves.toEqual(
+			expect.objectContaining({
+				close: expect.any(Function),
+			}),
+		);
 	});
 
 	it("should handle storage bucket events", () => {

--- a/src/app/chat/hooks/useConversations.ts
+++ b/src/app/chat/hooks/useConversations.ts
@@ -1,12 +1,12 @@
 "use client";
 
-import { Query } from "appwrite";
+import { Channel, Query } from "appwrite";
 import { useEffect, useCallback, useMemo } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { getEnvConfig } from "@/lib/appwrite-core";
 import { listConversations } from "@/lib/appwrite-dms-client";
-import { getSharedClient, trackSubscription } from "@/lib/realtime-pool";
+import { getSharedRealtime, trackSubscription } from "@/lib/realtime-pool";
 
 import { useStatusSubscription } from "./useStatusSubscription";
 
@@ -96,15 +96,18 @@ export function useConversations(userId: string | null, enabled = true) {
         let cleanupFn: (() => void) | undefined;
         let cancelled = false;
 
-        const conversationChannel = `databases.${env.databaseId}.collections.${CONVERSATIONS_COLLECTION}.documents`;
+        const conversationChannel = Channel.database(env.databaseId)
+            .collection(CONVERSATIONS_COLLECTION)
+            .document();
+        const conversationChannelKey = conversationChannel.toString();
 
-        void Promise.resolve().then(() => {
+        void Promise.resolve().then(async () => {
             if (cancelled) {
                 return;
             }
 
-            const client = getSharedClient();
-            const unsubscribe = client.subscribe(
+            const realtime = getSharedRealtime();
+            const subscription = await realtime.subscribe(
                 conversationChannel,
                 (response) => {
                     const payload = response.payload as Record<string, unknown>;
@@ -123,11 +126,11 @@ export function useConversations(userId: string | null, enabled = true) {
                 },
                 [Query.contains("participants", userId)],
             );
-            const untrack = trackSubscription(conversationChannel);
+            const untrack = trackSubscription(conversationChannelKey);
 
             cleanupFn = () => {
                 untrack();
-                unsubscribe();
+                void subscription.close();
             };
         });
 

--- a/src/app/chat/hooks/useDirectMessages.ts
+++ b/src/app/chat/hooks/useDirectMessages.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { Query } from "appwrite";
+import { Channel, Query } from "appwrite";
 import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import { toast } from "sonner";
 import { adaptDirectMessages } from "@/lib/chat-surface";
@@ -26,7 +26,7 @@ import {
     unpinDMMessage,
 } from "@/lib/thread-pin-client";
 import { listThreadReads, persistThreadReads } from "@/lib/thread-read-client";
-import { getSharedClient, trackSubscription } from "@/lib/realtime-pool";
+import { getSharedRealtime, trackSubscription } from "@/lib/realtime-pool";
 import { useThreadPinState } from "./useThreadPinState";
 
 const env = getEnvConfig();
@@ -270,60 +270,66 @@ export function useDirectMessages({
 
         let cleanupFn: (() => void) | undefined;
         let cancelled = false;
-        const messageChannel = `databases.${env.databaseId}.collections.${DIRECT_MESSAGES_COLLECTION}.documents`;
+        const messageChannel = Channel.database(env.databaseId)
+            .collection(DIRECT_MESSAGES_COLLECTION)
+            .document();
+        const messageChannelKey = messageChannel.toString();
 
-        void Promise.resolve().then(() => {
+        void Promise.resolve().then(async () => {
             if (cancelled) {
                 return;
             }
 
-            const client = getSharedClient();
-            const untrack = trackSubscription(messageChannel);
-            const unsubscribe = client.subscribe(messageChannel, (response) => {
-                const payload = response.payload as Record<string, unknown>;
-                const msgConversationId = payload.conversationId;
-                const events = response.events as string[];
+            const realtime = getSharedRealtime();
+            const untrack = trackSubscription(messageChannelKey);
+            const subscription = await realtime.subscribe(
+                messageChannel,
+                (response) => {
+                    const payload = response.payload as Record<string, unknown>;
+                    const msgConversationId = payload.conversationId;
+                    const events = response.events as string[];
 
-                // Only update if message belongs to this conversation
-                if (msgConversationId === conversationId) {
-                    const messageData = {
-                        ...(payload as unknown as DirectMessage),
-                        reactions: parseReactions(
-                            (payload as Record<string, unknown>).reactions as
-                                | string
-                                | undefined,
-                        ),
-                    };
-
-                    if (!isTopLevelMessage(messageData)) {
-                        return;
-                    }
-
-                    // Handle different event types to avoid full reload
-                    if (events.some((e) => e.endsWith(".create"))) {
-                        setMessages((prev) => {
-                            if (prev.some((m) => m.$id === messageData.$id)) {
-                                return prev;
-                            }
-                            return [...prev, messageData];
-                        });
-                    } else if (events.some((e) => e.endsWith(".update"))) {
-                        setMessages((prev) =>
-                            prev.map((m) =>
-                                m.$id === messageData.$id ? messageData : m,
+                    // Only update if message belongs to this conversation
+                    if (msgConversationId === conversationId) {
+                        const messageData = {
+                            ...(payload as unknown as DirectMessage),
+                            reactions: parseReactions(
+                                (payload as Record<string, unknown>).reactions as
+                                    | string
+                                    | undefined,
                             ),
-                        );
-                    } else if (events.some((e) => e.endsWith(".delete"))) {
-                        setMessages((prev) =>
-                            prev.filter((m) => m.$id !== messageData.$id),
-                        );
+                        };
+
+                        if (!isTopLevelMessage(messageData)) {
+                            return;
+                        }
+
+                        // Handle different event types to avoid full reload
+                        if (events.some((e) => e.endsWith(".create"))) {
+                            setMessages((prev) => {
+                                if (prev.some((m) => m.$id === messageData.$id)) {
+                                    return prev;
+                                }
+                                return [...prev, messageData];
+                            });
+                        } else if (events.some((e) => e.endsWith(".update"))) {
+                            setMessages((prev) =>
+                                prev.map((m) =>
+                                    m.$id === messageData.$id ? messageData : m,
+                                ),
+                            );
+                        } else if (events.some((e) => e.endsWith(".delete"))) {
+                            setMessages((prev) =>
+                                prev.filter((m) => m.$id !== messageData.$id),
+                            );
+                        }
                     }
-                }
-            });
+                },
+            );
 
             cleanupFn = () => {
                 untrack();
-                unsubscribe();
+                void subscription.close();
             };
         });
 
@@ -636,16 +642,19 @@ export function useDirectMessages({
 
         let cleanupFn: (() => void) | undefined;
         let cancelled = false;
-        const typingChannel = `databases.${databaseId}.collections.${TYPING_COLLECTION_ID}.documents`;
+        const typingChannel = Channel.database(databaseId)
+            .collection(TYPING_COLLECTION_ID)
+            .document();
+        const typingChannelKey = typingChannel.toString();
 
-        void Promise.resolve().then(() => {
+        void Promise.resolve().then(async () => {
             if (cancelled) {
                 return;
             }
-            const client = getSharedClient();
-            const untrack = trackSubscription(typingChannel);
+            const realtime = getSharedRealtime();
+            const untrack = trackSubscription(typingChannelKey);
 
-            const unsubscribe = client.subscribe(
+            const subscription = await realtime.subscribe(
                 typingChannel,
                 (response) => {
                     const payload = response.payload as Record<string, unknown>;
@@ -700,7 +709,7 @@ export function useDirectMessages({
 
             cleanupFn = () => {
                 untrack();
-                unsubscribe();
+                void subscription.close();
             };
         });
 

--- a/src/app/chat/hooks/useInbox.ts
+++ b/src/app/chat/hooks/useInbox.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { Channel } from "appwrite";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -11,7 +12,7 @@ import {
     markInboxScopeRead,
     type InboxScope,
 } from "@/lib/inbox-client";
-import { getSharedClient, trackSubscription } from "@/lib/realtime-pool";
+import { getSharedRealtime, trackSubscription } from "@/lib/realtime-pool";
 import type {
     InboxContextKind,
     InboxItem,
@@ -148,27 +149,27 @@ export function useInbox(userId: string | null) {
             env.collections.inboxItems,
             env.collections.messages,
             env.collections.threadReads,
-        ].map(
-            (collectionId) =>
-                `databases.${env.databaseId}.collections.${collectionId}.documents`,
+        ].map((collectionId) =>
+            Channel.database(env.databaseId).collection(collectionId).document(),
         );
+        const channelKeys = channels.map((channel) => channel.toString());
 
         let cleanupFn: (() => void) | undefined;
         let cancelled = false;
 
-        void Promise.resolve().then(() => {
+        void Promise.resolve().then(async () => {
             if (cancelled) {
                 return;
             }
 
-            const client = getSharedClient();
-            const unsubscribe = client.subscribe(channels, () => {
+            const realtime = getSharedRealtime();
+            const subscription = await realtime.subscribe(channels, () => {
                 void queryClient.invalidateQueries({
                     queryKey: getInboxQueryKey(userId),
                     refetchType: "active",
                 });
             });
-            const untrack = channels.map((channel) =>
+            const untrack = channelKeys.map((channel) =>
                 trackSubscription(channel),
             );
 
@@ -176,7 +177,7 @@ export function useInbox(userId: string | null) {
                 for (const stopTracking of untrack) {
                     stopTracking();
                 }
-                unsubscribe();
+                void subscription.close();
             };
         });
 

--- a/src/app/chat/hooks/useMessages.ts
+++ b/src/app/chat/hooks/useMessages.ts
@@ -1,5 +1,5 @@
 "use client";
-import { Query } from "appwrite";
+import { Channel, Query } from "appwrite";
 import type { RealtimeResponseEvent } from "appwrite";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -210,12 +210,15 @@ export function useMessages({
         let cancelled = false;
 
         import("@/lib/realtime-pool")
-            .then(({ getSharedClient, trackSubscription }) => {
+            .then(async ({ getSharedRealtime, trackSubscription }) => {
                 if (cancelled) {
                     return;
                 }
-                const c = getSharedClient();
-                const messageChannel = `databases.${databaseId}.collections.${collectionId}.documents`;
+                const realtime = getSharedRealtime();
+                const messageChannel = Channel.database(databaseId)
+                    .collection(collectionId)
+                    .document();
+                const messageChannelKey = messageChannel.toString();
 
                 function parseBase(
                     event: RealtimeResponseEvent<Record<string, unknown>>,
@@ -323,7 +326,7 @@ export function useMessages({
                         applyDelete(base);
                     }
                 }
-                const unsub = c.subscribe(
+                const subscription = await realtime.subscribe(
                     messageChannel,
                     (event: RealtimeResponseEvent<Record<string, unknown>>) => {
                         const base = parseBase(event);
@@ -338,11 +341,11 @@ export function useMessages({
                     [Query.equal("channelId", channelId)],
                 );
 
-                const untrack = trackSubscription(messageChannel);
+                const untrack = trackSubscription(messageChannelKey);
 
                 cleanupFn = () => {
                     untrack();
-                    unsub();
+                    void subscription.close();
                 };
             })
             .catch(() => {
@@ -374,12 +377,15 @@ export function useMessages({
         let cancelled = false;
 
         import("@/lib/realtime-pool")
-            .then(({ getSharedClient, trackSubscription }) => {
+            .then(async ({ getSharedRealtime, trackSubscription }) => {
                 if (cancelled) {
                     return;
                 }
-                const c = getSharedClient();
-                const typingChannel = `databases.${databaseId}.collections.${typingCollectionId}.documents`;
+                const realtime = getSharedRealtime();
+                const typingChannel = Channel.database(databaseId)
+                    .collection(typingCollectionId)
+                    .document();
+                const typingChannelKey = typingChannel.toString();
 
                 function parseTyping(
                     event: RealtimeResponseEvent<Record<string, unknown>>,
@@ -434,13 +440,15 @@ export function useMessages({
                     }
                 }
 
-                const unsub = c.subscribe(typingChannel, handleTypingEvent, [
-                    Query.equal("channelId", channelId),
-                ]);
-                const untrack = trackSubscription(typingChannel);
+                const subscription = await realtime.subscribe(
+                    typingChannel,
+                    handleTypingEvent,
+                    [Query.equal("channelId", channelId)],
+                );
+                const untrack = trackSubscription(typingChannelKey);
                 cleanupFn = () => {
                     untrack();
-                    unsub();
+                    void subscription.close();
                 };
             })
             .catch(() => {

--- a/src/app/chat/hooks/useStatusSubscription.ts
+++ b/src/app/chat/hooks/useStatusSubscription.ts
@@ -1,11 +1,11 @@
 "use client";
 
-import { Query } from "appwrite";
+import { Channel, Query } from "appwrite";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { getEnvConfig } from "@/lib/appwrite-core";
 import type { UserStatus } from "@/lib/types";
 import { normalizeStatus, type StatusLike } from "@/lib/status-normalization";
-import { getSharedClient, trackSubscription } from "@/lib/realtime-pool";
+import { getSharedRealtime, trackSubscription } from "@/lib/realtime-pool";
 
 const env = getEnvConfig();
 const STATUSES_COLLECTION = env.collections.statuses;
@@ -85,11 +85,14 @@ export function useStatusSubscription(userIds: string[]) {
                     return;
                 }
 
-                const client = getSharedClient();
-                const channel = `databases.${env.databaseId}.collections.${STATUSES_COLLECTION}.documents`;
+                const realtime = getSharedRealtime();
+                const channel = Channel.database(env.databaseId)
+                    .collection(STATUSES_COLLECTION)
+                    .document();
+                const channelKey = channel.toString();
 
                 const trackedIds = [...trackedUserIds];
-                cleanup = client.subscribe(
+                const subscription = await realtime.subscribe(
                     channel,
                     (response) => {
                         try {
@@ -124,11 +127,10 @@ export function useStatusSubscription(userIds: string[]) {
                     },
                     [Query.equal("userId", trackedIds)],
                 );
-                const untrack = trackSubscription(channel);
-                const unsubscribe = cleanup;
+                const untrack = trackSubscription(channelKey);
                 cleanup = () => {
                     untrack();
-                    unsubscribe();
+                    void subscription.close();
                 };
             } catch (err) {
                 if (process.env.NODE_ENV !== "production") {

--- a/src/app/moderation/ModerationMessageList.tsx
+++ b/src/app/moderation/ModerationMessageList.tsx
@@ -1,11 +1,12 @@
 "use client";
 
+import { Channel } from "appwrite";
 import { useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { getBrowserClient } from "@/lib/appwrite-core";
 import { ImageWithSkeleton } from "@/components/image-with-skeleton";
 import { MessageWithMentions } from "@/components/message-with-mentions";
 import { useCustomEmojis } from "@/hooks/useCustomEmojis";
+import { getSharedRealtime } from "@/lib/realtime-pool";
 import type { FileAttachment } from "@/lib/types";
 import {
     actionHardDeleteBound,
@@ -110,7 +111,7 @@ export function ModerationMessageList({
 
     useEffect(() => {
         // Subscribe to real-time updates for the messages collection
-        const client = getBrowserClient();
+        const realtime = getSharedRealtime();
         const databaseId = process.env.NEXT_PUBLIC_APPWRITE_DATABASE_ID;
         const messagesCollectionId =
             process.env.NEXT_PUBLIC_APPWRITE_MESSAGES_COLLECTION_ID;
@@ -119,34 +120,50 @@ export function ModerationMessageList({
             return;
         }
 
-        const unsubscribe = client.subscribe(
-            `databases.${databaseId}.collections.${messagesCollectionId}.documents`,
-            (response: { events: string[]; payload: unknown }) => {
-                const event = response.events[0];
-                const payload =
-                    response.payload as unknown as ModerationMessage;
+        let cleanup: (() => void) | undefined;
+        let cancelled = false;
 
-                if (event?.includes(".update")) {
-                    // Update existing message
-                    setMessages((prev) =>
-                        prev.map((m) =>
-                            m.$id === payload.$id ? { ...m, ...payload } : m,
-                        ),
-                    );
-                } else if (event?.includes(".delete")) {
-                    // Remove deleted message
-                    setMessages((prev) =>
-                        prev.filter((m) => m.$id !== payload.$id),
-                    );
-                } else if (event?.includes(".create")) {
-                    // Add new message at the top
-                    setMessages((prev) => [payload, ...prev]);
-                }
-            },
-        );
+        void (async () => {
+            const subscription = await realtime.subscribe(
+                Channel.database(databaseId)
+                    .collection(messagesCollectionId)
+                    .document(),
+                (response: { events: string[]; payload: unknown }) => {
+                    const event = response.events[0];
+                    const payload = response.payload as ModerationMessage;
+
+                    if (event?.includes(".update")) {
+                        // Update existing message
+                        setMessages((prev) =>
+                            prev.map((m) =>
+                                m.$id === payload.$id ? { ...m, ...payload } : m,
+                            ),
+                        );
+                    } else if (event?.includes(".delete")) {
+                        // Remove deleted message
+                        setMessages((prev) =>
+                            prev.filter((m) => m.$id !== payload.$id),
+                        );
+                    } else if (event?.includes(".create")) {
+                        // Add new message at the top
+                        setMessages((prev) => [payload, ...prev]);
+                    }
+                },
+            );
+
+            if (cancelled) {
+                void subscription.close();
+                return;
+            }
+
+            cleanup = () => {
+                void subscription.close();
+            };
+        })();
 
         return () => {
-            unsubscribe();
+            cancelled = true;
+            cleanup?.();
         };
     }, []);
 

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Channel } from "appwrite";
 import {
     createContext,
     useCallback,
@@ -18,7 +19,7 @@ import {
     setUserStatus as setUserStatusAPI,
 } from "@/lib/appwrite-status";
 import { normalizeStatus } from "@/lib/status-normalization";
-import { getSharedClient, trackSubscription } from "@/lib/realtime-pool";
+import { getSharedRealtime, trackSubscription } from "@/lib/realtime-pool";
 
 const env = getEnvConfig();
 
@@ -200,10 +201,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
                         return;
                     }
 
-                    const client = getSharedClient();
-                    const channel = `databases.${env.databaseId}.collections.${statusesCollection}.documents`;
+                    const realtime = getSharedRealtime();
+                    const channel = Channel.database(env.databaseId)
+                        .collection(statusesCollection)
+                        .document();
+                    const channelKey = channel.toString();
 
-                    cleanup = client.subscribe(channel, (response) => {
+                    const subscription = await realtime.subscribe(
+                        channel,
+                        (response) => {
                         try {
                             const payload = response.payload as
                                 | Record<string, unknown>
@@ -230,12 +236,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
                                 );
                             }
                         }
-                    });
-                    const untrack = trackSubscription(channel);
-                    const unsubscribe = cleanup;
+                        },
+                    );
+                    const untrack = trackSubscription(channelKey);
                     cleanup = () => {
                         untrack();
-                        unsubscribe();
+                        void subscription.close();
                     };
                 } catch (err) {
                     if (process.env.NODE_ENV !== "production") {

--- a/src/hooks/useCustomEmojis.ts
+++ b/src/hooks/useCustomEmojis.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import type { RealtimeResponseEvent } from "appwrite";
+import { Channel, type RealtimeResponseEvent } from "appwrite";
 import type { CustomEmoji } from "@/lib/types";
 
 const EMOJIS_STORAGE_KEY = "firepit_custom_emojis";
@@ -81,17 +81,18 @@ export function useCustomEmojis() {
 
     // Dynamically import realtime pool to avoid SSR issues
     import("@/lib/realtime-pool")
-      .then(({ getSharedClient, trackSubscription }) => {
+      .then(async ({ getSharedRealtime, trackSubscription }) => {
         const bucketId = process.env.NEXT_PUBLIC_APPWRITE_EMOJIS_BUCKET_ID;
         if (!bucketId) {
           return;
         }
 
-        const client = getSharedClient();
+        const realtime = getSharedRealtime();
         
         // Subscribe to all file events in the emojis bucket
-        const channel = `buckets.${bucketId}.files`;
-        const untrack = trackSubscription(channel);
+        const channel = Channel.bucket(bucketId).file();
+        const channelKey = channel.toString();
+        const untrack = trackSubscription(channelKey);
 
         const handleStorageEvent = (
           event: RealtimeResponseEvent<Record<string, unknown>>
@@ -109,11 +110,9 @@ export function useCustomEmojis() {
         };
 
         try {
-          const unsub = client.subscribe(channel, handleStorageEvent);
+          const subscription = await realtime.subscribe(channel, handleStorageEvent);
           unsubscribe = () => {
-            if (typeof unsub === "function") {
-              unsub();
-            }
+            void subscription.close();
             untrack();
           };
         } catch {

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { Channel } from "appwrite";
 import { useEffect, useRef, useCallback } from "react";
 import { getEnvConfig } from "@/lib/appwrite-core";
 
@@ -134,9 +135,12 @@ export function useNotifications({
         let untrack: (() => void) | undefined;
 
         import("@/lib/realtime-pool")
-            .then(({ getSharedClient, trackSubscription }) => {
-                const client = getSharedClient();
-                const messageChannel = `databases.${databaseId}.collections.${collectionId}.documents`;
+            .then(async ({ getSharedRealtime, trackSubscription }) => {
+                const realtime = getSharedRealtime();
+                const messageChannel = Channel.database(databaseId)
+                    .collection(collectionId)
+                    .document();
+                const messageChannelKey = messageChannel.toString();
 
                 const handleMessage = (event: {
                     events: string[];
@@ -224,8 +228,14 @@ export function useNotifications({
                     })();
                 };
 
-                unsubscribe = client.subscribe(messageChannel, handleMessage);
-                untrack = trackSubscription(messageChannel);
+                const subscription = await realtime.subscribe(
+                    messageChannel,
+                    handleMessage,
+                );
+                unsubscribe = () => {
+                    void subscription.close();
+                };
+                untrack = trackSubscription(messageChannelKey);
             })
             .catch(() => {
                 // Failed to set up realtime
@@ -260,9 +270,12 @@ export function useNotifications({
         let cleanup: (() => void) | undefined;
 
         import("@/lib/realtime-pool")
-            .then(({ getSharedClient, trackSubscription }) => {
-                const client = getSharedClient();
-                const messageChannel = `databases.${databaseId}.collections.${collectionId}.documents`;
+            .then(async ({ getSharedRealtime, trackSubscription }) => {
+                const realtime = getSharedRealtime();
+                const messageChannel = Channel.database(databaseId)
+                    .collection(collectionId)
+                    .document();
+                const messageChannelKey = messageChannel.toString();
 
                 const handleMessage = (response: {
                     events: string[];
@@ -336,15 +349,15 @@ export function useNotifications({
                     })();
                 };
 
-                const unsubscribe = client.subscribe(
+                const subscription = await realtime.subscribe(
                     messageChannel,
                     handleMessage,
                 );
-                const trackCleanup = trackSubscription(messageChannel);
+                const trackCleanup = trackSubscription(messageChannelKey);
 
                 // Store combined cleanup function
                 cleanup = () => {
-                    unsubscribe?.();
+                    void subscription.close();
                     trackCleanup?.();
                 };
             })

--- a/src/lib/realtime-pool.ts
+++ b/src/lib/realtime-pool.ts
@@ -4,9 +4,11 @@
  */
 
 import { Client } from "appwrite";
+import { Realtime } from "appwrite";
 import { getEnvConfig } from "@/lib/appwrite-core";
 
 let sharedClient: Client | null = null;
+let sharedRealtime: Realtime | null = null;
 const subscriptionRefs = new Map<string, number>();
 
 /**
@@ -31,6 +33,18 @@ export function getSharedClient(): Client {
     }
 
     return sharedClient;
+}
+
+/**
+ * Get or create shared Appwrite realtime helper
+ * @returns {Realtime} The return value.
+ */
+export function getSharedRealtime(): Realtime {
+    if (!sharedRealtime) {
+        sharedRealtime = new Realtime(getSharedClient());
+    }
+
+    return sharedRealtime;
 }
 
 /**


### PR DESCRIPTION
This pull request refactors all chat-related hooks and tests to use the new `getSharedRealtime` API (replacing `getSharedClient`) and Appwrite's `Channel` class for constructing realtime subscription channels. It also updates subscription handling to use the new async `.subscribe()` method, which returns a subscription object with a `.close()` method for cleanup. These changes modernize the codebase, improve type safety, and ensure compatibility with the latest Appwrite SDK.

**Migration to new Appwrite Realtime API:**

* All hooks (`useConversations`, `useDirectMessages`, `useInbox`, `useMessages`, `useStatusSubscription`) now use `getSharedRealtime` instead of `getSharedClient`, and construct channels using the `Channel` class for better type safety and clarity. [[1]](diffhunk://#diff-25e06741f4ee8ab984ee671ebae9d2bc8e2f54019b835725d3dadb0495716436L3-R9) [[2]](diffhunk://#diff-028d34731d89abddf3a201d93402f73771ac181e567c854cd351cc75ac34f962L3-R3) [[3]](diffhunk://#diff-511f2d5c7d09cc532e52d16400983bb2fd347eae59c0e4e3f557b652a09f94ceR3) [[4]](diffhunk://#diff-68249cd523448d809d8fc3cf97a836f61a279c4239c50bf9b3c96d41dbb7f8bdL2-R2) [[5]](diffhunk://#diff-45bef32499ef4fb219d44a420e1ec9b53b14dd46a8b0c7985c5baea4124ffb75L3-R8)
* Subscription setup in hooks is now `async`, awaiting the new `subscribe()` method which returns a subscription object with a `.close()` method, replacing the previous unsubscribe function pattern. Cleanup functions now call `.close()` on the subscription. [[1]](diffhunk://#diff-25e06741f4ee8ab984ee671ebae9d2bc8e2f54019b835725d3dadb0495716436L99-R110) [[2]](diffhunk://#diff-25e06741f4ee8ab984ee671ebae9d2bc8e2f54019b835725d3dadb0495716436L126-R133) [[3]](diffhunk://#diff-028d34731d89abddf3a201d93402f73771ac181e567c854cd351cc75ac34f962L273-R287) [[4]](diffhunk://#diff-028d34731d89abddf3a201d93402f73771ac181e567c854cd351cc75ac34f962L322-R332) [[5]](diffhunk://#diff-028d34731d89abddf3a201d93402f73771ac181e567c854cd351cc75ac34f962L639-R657) [[6]](diffhunk://#diff-028d34731d89abddf3a201d93402f73771ac181e567c854cd351cc75ac34f962L703-R712) [[7]](diffhunk://#diff-511f2d5c7d09cc532e52d16400983bb2fd347eae59c0e4e3f557b652a09f94ceL151-R180) [[8]](diffhunk://#diff-68249cd523448d809d8fc3cf97a836f61a279c4239c50bf9b3c96d41dbb7f8bdL213-R221) [[9]](diffhunk://#diff-68249cd523448d809d8fc3cf97a836f61a279c4239c50bf9b3c96d41dbb7f8bdL326-R329) [[10]](diffhunk://#diff-68249cd523448d809d8fc3cf97a836f61a279c4239c50bf9b3c96d41dbb7f8bdL341-R348) [[11]](diffhunk://#diff-68249cd523448d809d8fc3cf97a836f61a279c4239c50bf9b3c96d41dbb7f8bdL377-R388) [[12]](diffhunk://#diff-68249cd523448d809d8fc3cf97a836f61a279c4239c50bf9b3c96d41dbb7f8bdL437-R451) [[13]](diffhunk://#diff-45bef32499ef4fb219d44a420e1ec9b53b14dd46a8b0c7985c5baea4124ffb75L88-R95)

**Test updates for new API:**

* All relevant tests are updated to mock `getSharedRealtime` and the new async `subscribe()` signature, returning a mock object with a `.close()` method. [[1]](diffhunk://#diff-df784bb0051ceb86fc08736628ab6c3455cd2e3a28e2289c46841b798c42e6a1L42-R43) [[2]](diffhunk://#diff-df784bb0051ceb86fc08736628ab6c3455cd2e3a28e2289c46841b798c42e6a1L198-R214) [[3]](diffhunk://#diff-ac50cdaa42372acddd4a61c1b6e5c2378c99990bf593f003b17676adf55302e2L77-R78) [[4]](diffhunk://#diff-32b3cdc7f2a3198099e7fabc4420e04f454095fbd31b7ae10ed38a636af95902L83-R84) [[5]](diffhunk://#diff-b370d42afdd16e2885c026639d7299a82447d91175bfc540515e905762fd2b83L37-R41) [[6]](diffhunk://#diff-b370d42afdd16e2885c026639d7299a82447d91175bfc540515e905762fd2b83L96-R96)

**Channel tracking and cleanup improvements:**

* Channel keys are now derived via `.toString()` on the `Channel` object for consistent tracking and untracking of subscriptions. [[1]](diffhunk://#diff-25e06741f4ee8ab984ee671ebae9d2bc8e2f54019b835725d3dadb0495716436L126-R133) [[2]](diffhunk://#diff-028d34731d89abddf3a201d93402f73771ac181e567c854cd351cc75ac34f962L273-R287) [[3]](diffhunk://#diff-028d34731d89abddf3a201d93402f73771ac181e567c854cd351cc75ac34f962L639-R657) [[4]](diffhunk://#diff-511f2d5c7d09cc532e52d16400983bb2fd347eae59c0e4e3f557b652a09f94ceL151-R180) [[5]](diffhunk://#diff-68249cd523448d809d8fc3cf97a836f61a279c4239c50bf9b3c96d41dbb7f8bdL341-R348) [[6]](diffhunk://#diff-68249cd523448d809d8fc3cf97a836f61a279c4239c50bf9b3c96d41dbb7f8bdL437-R451) [[7]](diffhunk://#diff-45bef32499ef4fb219d44a420e1ec9b53b14dd46a8b0c7985c5baea4124ffb75L88-R95)

These changes streamline the realtime subscription logic, align the codebase with the latest Appwrite SDK practices, and improve maintainability and testability.[Copilot is generating a summary...]Agent-Logs-Url: https://github.com/acarlson33/firepit/sessions/958f92ef-0eeb-4810-9aeb-fc7322d74ce5