### PR TITLE
Basic Markdown support

### DIFF
--- a/src/__tests__/components/message-with-mentions.test.tsx
+++ b/src/__tests__/components/message-with-mentions.test.tsx
@@ -185,4 +185,96 @@ describe("MessageWithMentions", () => {
 		// Standard emoji should still work
 		expect(container.textContent).toContain("😄");
 	});
+
+	it("should render basic markdown formatting", () => {
+		render(
+			<MessageWithMentions
+				text="**Bold** _Italic_ ~~Struck~~"
+				currentUserId="user-1"
+			/>
+		);
+
+		expect(screen.getByText("Bold").closest("strong")).not.toBeNull();
+		expect(screen.getByText("Italic").closest("em")).not.toBeNull();
+		expect(screen.getByText("Struck").closest("del")).not.toBeNull();
+	});
+
+	it("should render safe markdown links with secure attributes", () => {
+		render(
+			<MessageWithMentions
+				text="Visit [Firepit](https://example.com/docs)"
+				currentUserId="user-1"
+			/>
+		);
+
+		const link = screen.getByRole("link", { name: "Firepit" });
+		expect(link.getAttribute("href")).toBe("https://example.com/docs");
+		expect(link.getAttribute("target")).toBe("_blank");
+		expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+	});
+
+	it("should not render unsafe javascript links", () => {
+		render(
+			<MessageWithMentions
+				text="Unsafe [click](javascript:alert('xss'))"
+				currentUserId="user-1"
+			/>
+		);
+
+		expect(screen.queryByRole("link", { name: "click" })).toBeNull();
+		expect(screen.getByText("click")).toBeInTheDocument();
+	});
+
+	it("should preserve mention highlighting inside markdown", () => {
+		const users = new Map([
+			[
+				"user-2",
+				{
+					userId: "user-2",
+					displayName: "TestUser",
+					avatarUrl: "",
+					status: "online",
+					pronouns: "they/them",
+				},
+			],
+		]);
+
+		render(
+			<MessageWithMentions
+				text="**Hello @TestUser**"
+				mentions={["TestUser"]}
+				users={users}
+				currentUserId="user-1"
+			/>
+		);
+
+		const mention = screen.getByTitle("TestUser (they/them)");
+		expect(mention.className).toContain("font-semibold");
+		expect(mention.closest("strong")).not.toBeNull();
+	});
+
+	it("should not convert shortcode emojis inside inline code", () => {
+		const customEmojis = [
+			{
+				fileId: "emoji-1",
+				url: "/api/emoji/emoji-1",
+				name: "party-parrot",
+			},
+		];
+
+		const { container } = render(
+			<MessageWithMentions
+				text="`:party-parrot:` outside :party-parrot:"
+				currentUserId="user-1"
+				customEmojis={customEmojis}
+			/>
+		);
+
+		const code = container.querySelector("code");
+		expect(code).not.toBeNull();
+		expect(code?.textContent).toBe(":party-parrot:");
+		expect(screen.getByRole("img").getAttribute("alt")).toBe(
+			":party-parrot:",
+		);
+	});
 });

--- a/src/components/message-with-mentions.tsx
+++ b/src/components/message-with-mentions.tsx
@@ -1,9 +1,24 @@
 "use client";
 
+import { Children, cloneElement, isValidElement } from "react";
+
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
 import type { MentionMatch } from "@/lib/mention-utils";
 import { parseMentions } from "@/lib/mention-utils";
 import { EmojiRenderer } from "@/components/emoji-renderer";
 import type { UserProfileData, CustomEmoji } from "@/lib/types";
+
+const MARKDOWN_PATTERN =
+    /(\*\*|__|~~|`|\[[^\]]+\]\([^)]+\)|^\s{0,3}(?:[-+*]|\d+\.)\s+|^\s{0,3}>\s+|^\s{0,3}#{1,6}\s+)/m;
+
+const SAFE_LINK_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
+
+type MentionToken = {
+    token: string;
+    element: React.ReactElement;
+};
 
 interface MessageWithMentionsProps {
     text: string;
@@ -31,64 +46,395 @@ export function MessageWithMentions({
     customEmojis = [],
 }: MessageWithMentionsProps) {
     const allMatches = findMentionSpans(text, mentions, knownNames);
+    const mentionTokens = createMentionTokens({
+        text,
+        matches: allMatches,
+        users,
+        currentUserId,
+    });
 
-    if (allMatches.length === 0) {
+    const textWithTokens = injectMentionTokens(text, allMatches, mentionTokens);
+
+    return (
+        <div className="min-w-0">
+            {renderMessageText({
+                customEmojis,
+                mentionTokens,
+                text: textWithTokens,
+            })}
+        </div>
+    );
+}
+
+function hasMarkdownSyntax(text: string): boolean {
+    return MARKDOWN_PATTERN.test(text);
+}
+
+function sanitizeLinkHref(href: string | undefined): string | null {
+    if (!href) {
+        return null;
+    }
+
+    const normalizedHref = href.trim();
+
+    if (!normalizedHref) {
+        return null;
+    }
+
+    if (
+        normalizedHref.startsWith("/") ||
+        normalizedHref.startsWith("#") ||
+        normalizedHref.startsWith("?")
+    ) {
+        return normalizedHref;
+    }
+
+    try {
+        const parsed = new URL(normalizedHref);
+        if (SAFE_LINK_PROTOCOLS.has(parsed.protocol)) {
+            return normalizedHref;
+        }
+    } catch {
+        return null;
+    }
+
+    return null;
+}
+
+function renderMessageText({
+    text,
+    customEmojis,
+    mentionTokens,
+}: {
+    text: string;
+    customEmojis: CustomEmoji[];
+    mentionTokens: MentionToken[];
+}) {
+    if (!hasMarkdownSyntax(text)) {
+        return renderDecoratedText({ text, customEmojis, mentionTokens });
+    }
+
+    return (
+        <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            skipHtml
+            components={{
+                p: ({ children }) => (
+                    <p className="my-1 first:mt-0 last:mb-0">
+                        {renderMarkdownChildren({
+                            children,
+                            customEmojis,
+                            mentionTokens,
+                        })}
+                    </p>
+                ),
+                strong: ({ children }) => (
+                    <strong className="font-semibold">
+                        {renderMarkdownChildren({
+                            children,
+                            customEmojis,
+                            mentionTokens,
+                        })}
+                    </strong>
+                ),
+                em: ({ children }) => (
+                    <em className="italic">
+                        {renderMarkdownChildren({
+                            children,
+                            customEmojis,
+                            mentionTokens,
+                        })}
+                    </em>
+                ),
+                del: ({ children }) => (
+                    <del className="opacity-80">
+                        {renderMarkdownChildren({
+                            children,
+                            customEmojis,
+                            mentionTokens,
+                        })}
+                    </del>
+                ),
+                ul: ({ children }) => (
+                    <ul className="my-1 list-disc pl-5">
+                        {renderMarkdownChildren({
+                            children,
+                            customEmojis,
+                            mentionTokens,
+                        })}
+                    </ul>
+                ),
+                ol: ({ children }) => (
+                    <ol className="my-1 list-decimal pl-5">
+                        {renderMarkdownChildren({
+                            children,
+                            customEmojis,
+                            mentionTokens,
+                        })}
+                    </ol>
+                ),
+                li: ({ children }) => (
+                    <li>
+                        {renderMarkdownChildren({
+                            children,
+                            customEmojis,
+                            mentionTokens,
+                        })}
+                    </li>
+                ),
+                blockquote: ({ children }) => (
+                    <blockquote className="my-1 border-l-2 border-border/70 pl-3 text-muted-foreground">
+                        {renderMarkdownChildren({
+                            children,
+                            customEmojis,
+                            mentionTokens,
+                        })}
+                    </blockquote>
+                ),
+                pre: ({ children }) => (
+                    <pre className="my-1 overflow-x-auto rounded-md border border-border/70 bg-muted/60 p-2 text-xs leading-5">
+                        {children}
+                    </pre>
+                ),
+                a: ({ children, href }) => {
+                    const safeHref = sanitizeLinkHref(href);
+
+                    if (!safeHref) {
+                        return (
+                            <span>
+                                {renderMarkdownChildren({
+                                    children,
+                                    customEmojis,
+                                    mentionTokens,
+                                })}
+                            </span>
+                        );
+                    }
+
+                    const isExternal =
+                        safeHref.startsWith("http://") ||
+                        safeHref.startsWith("https://");
+
+                    return (
+                        <a
+                            className="font-medium text-primary underline underline-offset-4"
+                            href={safeHref}
+                            rel={isExternal ? "noopener noreferrer" : undefined}
+                            target={isExternal ? "_blank" : undefined}
+                        >
+                            {renderMarkdownChildren({
+                                children,
+                                customEmojis,
+                                mentionTokens,
+                            })}
+                        </a>
+                    );
+                },
+                img: ({ alt }) => (
+                    <span className="italic text-muted-foreground">
+                        [{alt || "image"}]
+                    </span>
+                ),
+            }}
+        >
+            {text}
+        </ReactMarkdown>
+    );
+}
+
+function renderMarkdownChildren({
+    children,
+    customEmojis,
+    mentionTokens,
+}: {
+    children: React.ReactNode;
+    customEmojis: CustomEmoji[];
+    mentionTokens: MentionToken[];
+}): React.ReactNode {
+    return Children.map(children, (child) => {
+        if (typeof child === "string" || typeof child === "number") {
+            return renderDecoratedText({
+                text: String(child),
+                customEmojis,
+                mentionTokens,
+            });
+        }
+
+        if (
+            isValidElement<{ children?: React.ReactNode }>(child) &&
+            child.props.children !== undefined
+        ) {
+            if (
+                typeof child.type === "string" &&
+                (child.type === "code" || child.type === "pre")
+            ) {
+                return child;
+            }
+
+            return cloneElement(
+                child,
+                undefined,
+                renderMarkdownChildren({
+                    children: child.props.children,
+                    customEmojis,
+                    mentionTokens,
+                }),
+            );
+        }
+
+        return child;
+    });
+}
+
+function renderDecoratedText({
+    text,
+    customEmojis,
+    mentionTokens,
+}: {
+    text: string;
+    customEmojis: CustomEmoji[];
+    mentionTokens: MentionToken[];
+}): React.ReactNode {
+    if (mentionTokens.length === 0) {
         return <EmojiRenderer text={text} customEmojis={customEmojis} />;
     }
 
     const parts: React.ReactNode[] = [];
-    let lastIndex = 0;
+    let cursor = 0;
 
-    for (const [index, match] of allMatches.entries()) {
-        if (match.startIndex > lastIndex) {
+    while (cursor < text.length) {
+        let nextMatch:
+            | {
+                  token: string;
+                  index: number;
+                  element: React.ReactElement;
+              }
+            | null = null;
+
+        for (const mentionToken of mentionTokens) {
+            const tokenIndex = text.indexOf(mentionToken.token, cursor);
+            if (tokenIndex === -1) {
+                continue;
+            }
+
+            if (!nextMatch || tokenIndex < nextMatch.index) {
+                nextMatch = {
+                    token: mentionToken.token,
+                    index: tokenIndex,
+                    element: mentionToken.element,
+                };
+            }
+        }
+
+        if (!nextMatch) {
             parts.push(
                 <EmojiRenderer
-                    key={`text-${index}`}
-                    text={text.substring(lastIndex, match.startIndex)}
+                    key={`text-${cursor}`}
+                    text={text.substring(cursor)}
+                    customEmojis={customEmojis}
+                />,
+            );
+            break;
+        }
+
+        if (nextMatch.index > cursor) {
+            parts.push(
+                <EmojiRenderer
+                    key={`text-${cursor}`}
+                    text={text.substring(cursor, nextMatch.index)}
                     customEmojis={customEmojis}
                 />,
             );
         }
 
+        parts.push(
+            cloneElement(nextMatch.element, {
+                key: `mention-${nextMatch.index}`,
+            }),
+        );
+
+        cursor = nextMatch.index + nextMatch.token.length;
+    }
+
+    return <>{parts}</>;
+}
+
+function createMentionTokens({
+    text,
+    matches,
+    users,
+    currentUserId,
+}: {
+    text: string;
+    matches: MentionMatch[];
+    users: Map<string, UserProfileData>;
+    currentUserId?: string;
+}): MentionToken[] {
+    return matches.map((match, index) => {
         const mentionedUser = Array.from(users.values()).find((u) => {
             const displayName = u.displayName || "";
             return displayName.toLowerCase() === match.username.toLowerCase();
         });
 
         const isSelf = mentionedUser?.userId === currentUserId;
+        const token = createMentionToken(text, index);
 
-        parts.push(
-            <span
-                key={`mention-${index}`}
-                className={`rounded px-1 font-semibold ${
-                    isSelf
-                        ? "bg-primary/20 text-primary dark:bg-primary/30"
-                        : "bg-accent text-accent-foreground"
-                }`}
-                title={
-                    mentionedUser
-                        ? `${mentionedUser.displayName}${mentionedUser.pronouns ? ` (${mentionedUser.pronouns})` : ""}`
-                        : match.fullMatch
-                }
-            >
-                {match.fullMatch}
-            </span>,
-        );
+        return {
+            token,
+            element: (
+                <span
+                    className={`rounded px-1 font-semibold ${
+                        isSelf
+                            ? "bg-primary/20 text-primary dark:bg-primary/30"
+                            : "bg-accent text-accent-foreground"
+                    }`}
+                    title={
+                        mentionedUser
+                            ? `${mentionedUser.displayName}${mentionedUser.pronouns ? ` (${mentionedUser.pronouns})` : ""}`
+                            : match.fullMatch
+                    }
+                >
+                    {match.fullMatch}
+                </span>
+            ),
+        };
+    });
+}
 
+function createMentionToken(text: string, index: number): string {
+    let token = `FIREPITMENTIONTOKEN${index}X`;
+    while (text.includes(token)) {
+        token = `${token}X`;
+    }
+    return token;
+}
+
+function injectMentionTokens(
+    text: string,
+    matches: MentionMatch[],
+    mentionTokens: MentionToken[],
+): string {
+    if (matches.length === 0) {
+        return text;
+    }
+
+    const parts: string[] = [];
+    let lastIndex = 0;
+
+    for (const [index, match] of matches.entries()) {
+        if (match.startIndex > lastIndex) {
+            parts.push(text.substring(lastIndex, match.startIndex));
+        }
+
+        parts.push(mentionTokens[index]?.token || match.fullMatch);
         lastIndex = match.endIndex;
     }
 
     if (lastIndex < text.length) {
-        parts.push(
-            <EmojiRenderer
-                key="text-end"
-                text={text.substring(lastIndex)}
-                customEmojis={customEmojis}
-            />,
-        );
+        parts.push(text.substring(lastIndex));
     }
 
-    return <span>{parts}</span>;
+    return parts.join("");
 }
 
 /**

--- a/src/components/search-results.tsx
+++ b/src/components/search-results.tsx
@@ -158,13 +158,13 @@ export function SearchResults({
                                 )}
                             </div>
 
-                            <p className="mt-1 text-muted-foreground text-sm">
+                            <div className="mt-1 text-muted-foreground text-sm">
                                 <MessageWithMentions
                                     text={truncateText(message.text)}
                                     currentUserId=""
                                     customEmojis={customEmojis}
                                 />
-                            </p>
+                            </div>
 
                             {message.editedAt && (
                                 <span className="mt-1 text-muted-foreground text-xs italic">


### PR DESCRIPTION
This pull request adds robust Markdown support to the `MessageWithMentions` component, ensuring safe rendering of links and proper handling of mentions, emojis, and formatting. It also updates the test suite to cover these new behaviors and makes a minor UI adjustment in the search results.

**Markdown rendering and safety improvements:**

* [`src/components/message-with-mentions.tsx`](diffhunk://#diff-d1a1c35b01df0e2feaede7551295e825e7408dc4b5000f33aeffbca682b4279dR3-R22): Integrates `react-markdown` with `remark-gfm` to support basic Markdown formatting (bold, italic, strikethrough, lists, blockquotes, links, code, etc.) in messages. Ensures that only safe links (http, https, mailto, or relative) are rendered as clickable, with external links opening in a new tab and using `rel="noopener noreferrer"` for security. Unsafe links (e.g., `javascript:`) are not rendered as links. [[1]](diffhunk://#diff-d1a1c35b01df0e2feaede7551295e825e7408dc4b5000f33aeffbca682b4279dR3-R22) [[2]](diffhunk://#diff-d1a1c35b01df0e2feaede7551295e825e7408dc4b5000f33aeffbca682b4279dR49-L62)

* [`src/components/message-with-mentions.tsx`](diffhunk://#diff-d1a1c35b01df0e2feaede7551295e825e7408dc4b5000f33aeffbca682b4279dR49-L62): Mentions are tokenized and injected into the Markdown rendering flow, preserving highlighting and formatting even inside Markdown elements. Custom emoji rendering is disabled inside inline code blocks to prevent accidental parsing. [[1]](diffhunk://#diff-d1a1c35b01df0e2feaede7551295e825e7408dc4b5000f33aeffbca682b4279dR49-L62) [[2]](diffhunk://#diff-d1a1c35b01df0e2feaede7551295e825e7408dc4b5000f33aeffbca682b4279dL75-R437)

**Test coverage:**

* [`src/__tests__/components/message-with-mentions.test.tsx`](diffhunk://#diff-6f3161e9bcb5c78a067ff861a9e03cd7908b4121ffdf8e00cdf8056f7e5968d5R188-R279): Adds comprehensive tests for Markdown formatting, safe and unsafe link rendering, mention highlighting inside Markdown, and emoji handling inside code spans.

**UI consistency:**

* [`src/components/search-results.tsx`](diffhunk://#diff-aad0bdddf8b1b911692f32a488e08c59f0bc46d69f9805cd457a772708d67c24L161-R167): Changes the container for message previews from a `<p>` to a `<div>` to better support nested Markdown elements and avoid invalid HTML.